### PR TITLE
 Add dynamic return type extensions for getRepository() methods

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -12,8 +12,14 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-		class: PHPStan\Type\Doctrine\EntityManagerGetRepositoryDynamicReturnTypeExtension
+		class: PHPStan\Type\Doctrine\ObjectManagerGetRepositoryDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\Type\Doctrine\ManagerRegistryGetRepositoryDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
 		class: Doctrine\Common\Annotations\AnnotationReader
+		setup:
+			- Doctrine\Common\Annotations\AnnotationRegistry::registerLoader( class_exists )

--- a/extension.neon
+++ b/extension.neon
@@ -11,3 +11,9 @@ services:
 		class: PHPStan\Type\Doctrine\EntityManagerFindDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\Type\Doctrine\EntityManagerGetRepositoryDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Doctrine\Common\Annotations\AnnotationReader

--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\ORM\Mapping\Entity;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+{
+
+	/**
+	 * @var \PHPStan\Broker\Broker
+	 */
+	private $broker;
+
+	/**
+	 * @var \Doctrine\Common\Annotations\Reader
+	 */
+	private $annotationReader;
+
+	public function __construct(Broker $broker, Reader $annotationReader)
+	{
+		$this->broker = $broker;
+		$this->annotationReader = $annotationReader;
+	}
+
+	public static function getClass(): string
+	{
+		return \Doctrine\ORM\EntityManager::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return in_array($methodReflection->getName(), [
+			'getRepository',
+		], true);
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		if (count($methodCall->args) === 0) {
+			return $methodReflection->getReturnType();
+		}
+		$arg = $methodCall->args[0]->value;
+		if (!($arg instanceof \PhpParser\Node\Expr\ClassConstFetch)) {
+			return $methodReflection->getReturnType();
+		}
+
+		$class = $arg->class;
+		if (!($class instanceof \PhpParser\Node\Name)) {
+			return $methodReflection->getReturnType();
+		}
+
+		$class = (string) $class;
+
+		if ($class === 'static') {
+			return $methodReflection->getReturnType();
+		}
+
+		if ($class === 'self') {
+			$class = $scope->getClassReflection()->getName();
+		}
+
+		if (!$this->broker->hasClass($class)) {
+			return $methodReflection->getReturnType();
+		}
+
+		$classReflection = $this->broker->getClass($class);
+		$annotations = $this->annotationReader
+			->getClassAnnotations($classReflection->getNativeReflection());
+
+		foreach ($annotations as $annotation) {
+			if (
+				$annotation instanceof Entity &&
+				$annotation->repositoryClass &&
+				$this->broker->hasClass($annotation->repositoryClass)
+			) {
+				return new ObjectType($annotation->repositoryClass);
+			}
+		}
+
+		return $methodReflection->getReturnType();
+	}
+
+}

--- a/src/Type/Doctrine/ManagerRegistryGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/ManagerRegistryGetRepositoryDynamicReturnTypeExtension.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+class ManagerRegistryGetRepositoryDynamicReturnTypeExtension extends AbstractGetRepositoryDynamicReturnTypeExtension
+{
+
+	public static function getClass(): string
+	{
+		return \Doctrine\Common\Persistence\ManagerRegistry::class;
+	}
+
+}

--- a/src/Type/Doctrine/ObjectManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/ObjectManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+class ObjectManagerGetRepositoryDynamicReturnTypeExtension extends AbstractGetRepositoryDynamicReturnTypeExtension
+{
+
+	public static function getClass(): string
+	{
+		return \Doctrine\Common\Persistence\ObjectManager::class;
+	}
+
+}


### PR DESCRIPTION
Extract repository class from `@Entity` annotation and use it as return type of `getRepository()` methods on `EntityManager` and `ManagerRegistry`.