### PR TITLE
Add tests for existing extensions

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
 	ignoreErrors:
 		- '#but returns PHPUnit_Framework_MockObject_MockObject#'
+		- '#PHPUnit_Framework_MockObject_MockObject given#'
+		- '#Access to an undefined property PHPUnit_Framework_MockObject_MockObject::\$\w+#'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,4 @@
 parameters:
-	ignoreErrors: []
+	ignoreErrors:
+		- '#but returns PHPUnit_Framework_MockObject_MockObject#'
+

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -2,6 +2,7 @@
 <ruleset name="PHPStan Doctrine extensions">
 	<rule ref="vendor/consistence/coding-standard/Consistence/ruleset.xml"/>
 	<rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
+		<exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingConstantVisibility"/>
 		<exclude name="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>

--- a/tests/PHPStan/Reflection/Doctrine/DoctrineSelectableClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Doctrine/DoctrineSelectableClassReflectionExtensionTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\PHPStan\Reflection\Doctrine;
+
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Doctrine\DoctrineSelectableClassReflectionExtension;
+use PHPStan\Reflection\MethodReflection;
+use PHPUnit\Framework\TestCase;
+
+final class DoctrineSelectableClassReflectionExtensionTest extends TestCase
+{
+
+	/** @var \PHPStan\Reflection\Doctrine\DoctrineSelectableClassReflectionExtension */
+	private $extension;
+
+	protected function setUp()
+	{
+		$broker = $this->mockBroker();
+
+		$this->extension = new DoctrineSelectableClassReflectionExtension();
+		$this->extension->setBroker($broker);
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function dataHasMethod(): array
+	{
+		return [
+			[\Doctrine\Common\Collections\Collection::class, 'matching', true],
+			[\Doctrine\Common\Collections\Collection::class, 'foo', false],
+		];
+	}
+
+	/**
+	 * @dataProvider dataHasMethod
+	 * @param string $className
+	 * @param string $method
+	 * @param bool $expectedResult
+	 */
+	public function testHasMethod(string $className, string $method, bool $expectedResult)
+	{
+		$classReflection = $this->mockClassReflection(new \ReflectionClass($className));
+		$this->assertSame($expectedResult, $this->extension->hasMethod($classReflection, $method));
+	}
+
+	public function testGetMethod()
+	{
+		$classReflection = $this->mockClassReflection(new \ReflectionClass(\Doctrine\Common\Collections\Collection::class));
+		$methodReflection = $this->extension->getMethod($classReflection, 'matching');
+		$this->assertSame('matching', $methodReflection->getName());
+	}
+
+	private function mockBroker(): Broker
+	{
+		$broker = $this->createMock(Broker::class);
+
+		$broker->method('getClass')->willReturnCallback(
+			function (string $className): ClassReflection {
+				return $this->mockClassReflection(new \ReflectionClass($className));
+			}
+		);
+
+		return $broker;
+	}
+
+	private function mockClassReflection(\ReflectionClass $reflectionClass): ClassReflection
+	{
+		$classReflection = $this->createMock(ClassReflection::class);
+		$classReflection->method('getName')->willReturn($reflectionClass->getName());
+		$classReflection->method('getMethod')->willReturnCallback(
+			function (string $method) use ($reflectionClass): MethodReflection {
+				return $this->mockMethodReflection($reflectionClass->getMethod($method));
+			}
+		);
+
+		return $classReflection;
+	}
+
+	private function mockMethodReflection(\ReflectionMethod $method): MethodReflection
+	{
+		$methodReflection = $this->createMock(MethodReflection::class);
+		$methodReflection->method('getName')->willReturn($method->getName());
+		return $methodReflection;
+	}
+
+}

--- a/tests/PHPStan/Type/Doctrine/DoctrineSelectableDynamicReturnTypeExtensionTest.php
+++ b/tests/PHPStan/Type/Doctrine/DoctrineSelectableDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\PHPStan\Type\Doctrine;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Doctrine\DoctrineSelectableDynamicReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPUnit\Framework\TestCase;
+
+final class DoctrineSelectableDynamicReturnTypeExtensionTest extends TestCase
+{
+
+	/** @var \PHPStan\Type\Doctrine\DoctrineSelectableDynamicReturnTypeExtension */
+	private $extension;
+
+	protected function setUp()
+	{
+		$this->extension = new DoctrineSelectableDynamicReturnTypeExtension();
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function dataIsMethodSupported(): array
+	{
+		return [
+			['matching', true],
+			['filter', false],
+			['foo', false],
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsMethodSupported
+	 * @param string $method
+	 * @param bool $expectedResult
+	 */
+	public function testIsMethodSupported(string $method, bool $expectedResult)
+	{
+		$methodReflection = $this->createMock(MethodReflection::class);
+		$methodReflection->method('getName')->willReturn($method);
+		$this->assertSame($expectedResult, $this->extension->isMethodSupported($methodReflection));
+	}
+
+	public function testGetTypeFromMethodCall()
+	{
+		$methodReflection = $this->createMock(MethodReflection::class);
+
+		$scope = $this->createMock(Scope::class);
+		$scope->method('getType')->will(
+			self::returnCallback(
+				function (\PhpParser\Node\Expr $node): Type {
+					return new ObjectType($node->getType());
+				}
+			)
+		);
+
+		$var = $this->createMock(Expr::class);
+		$var->method('getType')->willReturn(\Doctrine\Common\Collections\Collection::class);
+		$methodCall = $this->createMock(MethodCall::class);
+		$methodCall->var = $var;
+
+		$resultType = $this->extension->getTypeFromMethodCall($methodReflection, $methodCall, $scope);
+
+		$this->assertInstanceOf(ObjectType::class, $resultType);
+		$this->assertSame(\Doctrine\Common\Collections\Collection::class, $resultType->describe());
+	}
+
+}

--- a/tests/PHPStan/Type/Doctrine/EntityManagerFindDynamicReturnTypeExtensionTest.php
+++ b/tests/PHPStan/Type/Doctrine/EntityManagerFindDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,253 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\PHPStan\Type\Doctrine;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Doctrine\EntityManagerFindDynamicReturnTypeExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use PHPUnit\Framework\TestCase;
+
+final class EntityManagerFindDynamicReturnTypeExtensionTest extends TestCase
+{
+
+	const ENTITY_CLASS_NAME = '\\Foo\\Bar';
+
+	/** @var \PHPStan\Type\Doctrine\EntityManagerFindDynamicReturnTypeExtension */
+	private $extension;
+
+	protected function setUp()
+	{
+		$this->extension = new EntityManagerFindDynamicReturnTypeExtension();
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function dataIsMethodSupported(): array
+	{
+		return [
+			['find', true],
+			['getReference', true],
+			['getPartialReference', true],
+			['copy', false],
+			['foo', false],
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsMethodSupported
+	 * @param string $method
+	 * @param bool $expectedResult
+	 */
+	public function testIsMethodSupported(string $method, bool $expectedResult)
+	{
+		$methodReflection = $this->createMock(MethodReflection::class);
+		$methodReflection->method('getName')->willReturn($method);
+		$this->assertSame($expectedResult, $this->extension->isMethodSupported($methodReflection));
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function dataGetTypeFromMethodCallWithClassConstFetch(): array
+	{
+		return [
+			[
+				self::ENTITY_CLASS_NAME,
+				'find',
+				new UnionType([new ObjectType(self::ENTITY_CLASS_NAME), new NullType()]),
+			],
+			[
+				'self',
+				'find',
+				new UnionType([new ObjectType(self::ENTITY_CLASS_NAME), new NullType()]),
+			],
+			[
+				'static',
+				'find',
+				new ObjectWithoutClassType(),
+			],
+			[
+				self::ENTITY_CLASS_NAME,
+				'getReference',
+				new ObjectType(self::ENTITY_CLASS_NAME),
+			],
+			[
+				'self',
+				'getReference',
+				new ObjectType(self::ENTITY_CLASS_NAME),
+			],
+			[
+				'static',
+				'getReference',
+				new ObjectWithoutClassType(),
+			],
+			[
+				self::ENTITY_CLASS_NAME,
+				'getPartialReference',
+				new ObjectType(self::ENTITY_CLASS_NAME),
+			],
+			[
+				'self',
+				'getPartialReference',
+				new ObjectType(self::ENTITY_CLASS_NAME),
+			],
+			[
+				'static',
+				'getPartialReference',
+				new ObjectWithoutClassType(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetTypeFromMethodCallWithClassConstFetch
+	 * @param string $entityClassName
+	 * @param string $method
+	 * @param \PHPStan\Type\Type $expectedResult
+	 */
+	public function testGetTypeFromMethodCallWithClassConstFetch(
+		string $entityClassName,
+		string $method,
+		Type $expectedResult
+	)
+	{
+		$methodReflection = $this->mockMethodReflection($method);
+		$scope = $this->mockScope();
+		$methodCall = $this->mockMethodCallWithClassConstFetch($entityClassName);
+
+		$resultType = $this->extension->getTypeFromMethodCall($methodReflection, $methodCall, $scope);
+
+		$this->assertInstanceOf(get_class($expectedResult), $resultType);
+		$this->assertSame($expectedResult->describe(), $resultType->describe());
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function dataGetTypeFromMethodCallWithScalarString(): array
+	{
+		return [
+			[
+				self::ENTITY_CLASS_NAME,
+				'find',
+				new ObjectWithoutClassType(),
+			],
+			[
+				'self',
+				'find',
+				new ObjectWithoutClassType(),
+			],
+			[
+				'static',
+				'find',
+				new ObjectWithoutClassType(),
+			],
+			[
+				self::ENTITY_CLASS_NAME,
+				'getReference',
+				new ObjectWithoutClassType(),
+			],
+			[
+				'self',
+				'getReference',
+				new ObjectWithoutClassType(),
+			],
+			[
+				'static',
+				'getReference',
+				new ObjectWithoutClassType(),
+			],
+			[
+				self::ENTITY_CLASS_NAME,
+				'getPartialReference',
+				new ObjectWithoutClassType(),
+			],
+			[
+				'self',
+				'getPartialReference',
+				new ObjectWithoutClassType(),
+			],
+			[
+				'static',
+				'getPartialReference',
+				new ObjectWithoutClassType(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetTypeFromMethodCallWithScalarString
+	 * @param string $entityClassName
+	 * @param string $method
+	 * @param \PHPStan\Type\Type $expectedResult
+	 */
+	public function testGetTypeFromMethodCallWithScalarString(
+		string $entityClassName,
+		string $method,
+		Type $expectedResult
+	)
+	{
+		$methodReflection = $this->mockMethodReflection($method);
+		$scope = $this->mockScope();
+		$methodCall = $this->mockMethodCallWithScalarString($entityClassName);
+
+		$resultType = $this->extension->getTypeFromMethodCall($methodReflection, $methodCall, $scope);
+
+		$this->assertInstanceOf(get_class($expectedResult), $resultType);
+		$this->assertSame($expectedResult->describe(), $resultType->describe());
+	}
+
+	private function mockMethodReflection(string $method): MethodReflection
+	{
+		$methodReflection = $this->createMock(MethodReflection::class);
+		$methodReflection->method('getReturnType')->willReturn(new ObjectWithoutClassType());
+		$methodReflection->method('getName')->willReturn($method);
+		return $methodReflection;
+	}
+
+	private function mockScope(): Scope
+	{
+		$scope = $this->createMock(Scope::class);
+		$scope->method('getClassReflection')->willReturnCallback(
+			function (): ClassReflection {
+				$classReflection = $this->createMock(ClassReflection::class);
+				$classReflection->method('getName')->willReturn(self::ENTITY_CLASS_NAME);
+				return $classReflection;
+			}
+		);
+		return $scope;
+	}
+
+	private function mockMethodCallWithClassConstFetch(string $entityClassName): \PhpParser\Node\Expr\MethodCall
+	{
+		$class = new \PhpParser\Node\Name($entityClassName);
+		$value = new \PhpParser\Node\Expr\ClassConstFetch($class, 'class');
+		$arg = new \PhpParser\Node\Arg($value);
+
+		$methodCall = $this->createMock(\PhpParser\Node\Expr\MethodCall::class);
+		$methodCall->args = [
+			0 => $arg,
+		];
+		return $methodCall;
+	}
+
+	private function mockMethodCallWithScalarString(string $entityClassName): \PhpParser\Node\Expr\MethodCall
+	{
+		$value = new \PhpParser\Node\Scalar\String_($entityClassName);
+		$arg = new \PhpParser\Node\Arg($value);
+
+		$methodCall = $this->createMock(\PhpParser\Node\Expr\MethodCall::class);
+		$methodCall->args = [
+			0 => $arg,
+		];
+		return $methodCall;
+	}
+
+}


### PR DESCRIPTION
Unit tests for `DoctrineSelectableClassReflectionExtension`, `DoctrineSelectableDynamicReturnTypeExtension` and `EntityManagerFindDynamicReturnTypeExtension`.

