### PR TITLE
Dynamic return type for EntityManager#merge

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -22,6 +22,10 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
+		class: PHPStan\Type\Doctrine\EntityManagerMergeDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
 		class: PHPStan\Type\Doctrine\EntityRepositoryDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/extension.neon
+++ b/extension.neon
@@ -22,7 +22,7 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-		class: PHPStan\Type\Doctrine\EntityManagerMergeDynamicReturnTypeExtension
+		class: PHPStan\Type\Doctrine\ObjectManagerMergeDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-

--- a/src/Type/Doctrine/EntityManagerMergeDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerMergeDynamicReturnTypeExtension.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Type;
+
+class EntityManagerMergeDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \Doctrine\ORM\EntityManager::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'merge';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		if (count($methodCall->args) === 0) {
+			return $methodReflection->getReturnType();
+		}
+
+		return $scope->getType($methodCall->args[0]->value);
+	}
+
+}

--- a/src/Type/Doctrine/ObjectManagerMergeDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/ObjectManagerMergeDynamicReturnTypeExtension.php
@@ -7,12 +7,12 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
 
-class EntityManagerMergeDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+class ObjectManagerMergeDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
 	public function getClass(): string
 	{
-		return \Doctrine\ORM\EntityManager::class;
+		return \Doctrine\Common\Persistence\ObjectManager::class;
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool


### PR DESCRIPTION
Dynamically determine the return type of `EntityManager#merge`.

The merge function takes a single argument, the entity object  to re-attach with the EM. It passes back a managed copy of the entity, hence the return type is type of first argument.