### PR TITLE
Add support for getRepository() call on ObjectManager interface

### DIFF
--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -22,7 +22,7 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 
 	public function getClass(): string
 	{
-		return \Doctrine\ORM\EntityManager::class;
+		return \Doctrine\Common\Persistence\ObjectManager::class;
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool


### PR DESCRIPTION
In our code we mostly typehint entity manager as `EntityManagerInterface` or even `ObjectManager` interface. This change should add support for them as well as for doctrine ODM's `DocumentManager`.