### PR TITLE
[PoC] Resolve custom repository classes

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,6 +1,7 @@
 parameters:
 	doctrine:
 		repositoryClass: Doctrine\ORM\EntityRepository
+		metadata: []
 
 services:
 	-
@@ -18,7 +19,7 @@ services:
 	-
 		class: PHPStan\Type\Doctrine\EntityManagerGetRepositoryDynamicReturnTypeExtension
 		arguments:
-			repositoryClass: %doctrine.repositoryClass%
+			metadataProvider: @PHPStan\DoctrineClassMetadataProvider
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
@@ -29,3 +30,9 @@ services:
 		class: PHPStan\Type\Doctrine\EntityRepositoryDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\DoctrineClassMetadataProvider
+		arguments:
+			repositoryClass: %doctrine.repositoryClass%
+			mapping: %doctrine.metadata%
+

--- a/src/DoctrineClassMetadataProvider.php
+++ b/src/DoctrineClassMetadataProvider.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping;
+use Doctrine\ORM\Proxy\ProxyFactory;
+
+class DoctrineClassMetadataProvider
+{
+
+    /**
+     * @var EntityManager
+     */
+    private $em;
+
+    /**
+     * @var string
+     */
+    private $repositoryClass;
+
+    public function __construct(string $repositoryClass, array $mapping)
+    {
+        $configuration = new Configuration();
+        $configuration->setDefaultRepositoryClassName($repositoryClass);
+        $configuration->setMetadataDriverImpl($this->setupMappingDriver($mapping));
+        $configuration->setProxyDir('/dev/null');
+        $configuration->setProxyNamespace('__DP__');
+        $configuration->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
+        $evm = new EventManager();
+        $this->em = EntityManager::create(
+            \Doctrine\DBAL\DriverManager::getConnection(['host' => '/:memory:', 'driver' => 'pdo_sqlite'], $configuration, $evm),
+            $configuration,
+            $evm
+        );
+        $this->repositoryClass = $repositoryClass;
+    }
+
+    private function setupMappingDriver(array $mapping): MappingDriver
+    {
+        $driver = new MappingDriverChain();
+        foreach ($mapping as $namespace => $config) {
+            switch ($config['type']) {
+                case 'annotation':
+                    $nested = new Mapping\Driver\AnnotationDriver(new AnnotationReader(), $config['paths']);
+                    break;
+                case 'yml':
+                case 'yaml':
+                    $nested = new Mapping\Driver\YamlDriver($config['paths']);
+                    break;
+                case 'xml':
+                    $nested = new Mapping\Driver\XmlDriver($config['paths']);
+                    break;
+                default:
+                    throw new \InvalidArgumentException('Unknown mapping type: ' . $config['type']);
+            }
+            $driver->addDriver($nested, $namespace);
+        }
+        return $driver;
+    }
+
+    public function getBaseRepositoryClass(): string
+    {
+        return $this->repositoryClass;
+    }
+
+    /**
+     * @throws \Doctrine\Common\Persistence\Mapping\MappingException
+     * @throws \ReflectionException
+     */
+    public function getMetadataFor(string $className): Mapping\ClassMetadataInfo
+    {
+        return $this->em->getClassMetadata($className);
+    }
+    
+}

--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -2,23 +2,27 @@
 
 namespace PHPStan\Type\Doctrine;
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DoctrineClassMetadataProvider;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
 
 class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
-	/**
-	 * @var string
-	 */
-	private $repositoryClass;
+    /**
+     * @var DoctrineClassMetadataProvider
+     */
+    private $metadataProvider;
 
-	public function __construct(string $repositoryClass)
+    public function __construct(DoctrineClassMetadataProvider $metadataProvider)
 	{
-		$this->repositoryClass = $repositoryClass;
-	}
+        $this->metadataProvider = $metadataProvider;
+        AnnotationRegistry::registerLoader('class_exists');
+    }
 
 	public function getClass(): string
 	{
@@ -58,7 +62,12 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 			$class = $scope->getClassReflection()->getName();
 		}
 
-		return new EntityRepositoryType($class, $this->repositoryClass);
+        try {
+            $metadata = $this->metadataProvider->getMetadataFor($class);
+            return new EntityRepositoryType($class, $metadata->customRepositoryClassName ?: $this->metadataProvider->getBaseRepositoryClass());
+        } catch (MappingException $e) {
+		    return new EntityRepositoryType($class, $this->metadataProvider->getBaseRepositoryClass());
+        }
 	}
 
 }


### PR DESCRIPTION
This is only a proof of concept, has some rough edges (including CS) and obviously needs tests. FWIW it does work :) I'm opening this PR to see whether such approach would be accepted to not waste time.

Motivation behind creating dummy entity manager is that we get support for all mapping formats out of the box and don't need to resolve mappings on our own. With this we'll be able to get same mappings as Doctrine has so it opens possibilities to more checks.

Example of configuration:

```
includes:
    - vendor/phpstan/phpstan-doctrine/extension.neon
parameters:
    doctrine:
        metadata:
            CmsBundle\Entity:
                type: annotation
                paths: [%rootDir%/../../../src/CmsBundle/Entity]
```

