### PR TITLE
Only override repository return type for entity managers

### DIFF
--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -23,7 +23,7 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 
 	public function getClass(): string
 	{
-		return 'Doctrine\Common\Persistence\ObjectManager';
+		return 'Doctrine\ORM\EntityManagerInterface';
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool


### PR DESCRIPTION
The ObjectManager interface is shared across multiple projects, so assuming every object manager returns an entity repository is wrong and breaks using the extension with MongoDB ODM.

In addition to that, I would suggest renaming the generic extensions to `ObjectManager...` since they affect all object managers, not just an `EntityManager`. I wasn't sure if that would be considered a BC break so I left the refactoring out. Would you be open to renaming the classes?