### PR TITLE
[WIP] Use real object managers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 7.1
   - 7.2
 before_script:
+  - pecl install -f mongodb-stable
   - composer self-update
   - composer install
 script:

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,15 @@
 		"slevomat/coding-standard": "^4.5.2",
 		"doctrine/common": "^2.7",
 		"doctrine/orm": "^2.5",
-		"doctrine/collections": "^1.0"
+		"doctrine/collections": "^1.0",
+		"doctrine/mongodb-odm": "^1.2",
+		"alcaeus/mongo-php-adapter": "^1.1"
 	},
 	"conflict": {
 		"doctrine/common": "<2.7",
 		"doctrine/orm": "<2.5",
-		"doctrine/collections": "<1.0"
+		"doctrine/collections": "<1.0",
+		"doctrine/mongodb-odm": "<1.2"
 	},
 	"autoload": {
 		"psr-4": {
@@ -39,5 +42,10 @@
 	},
 	"autoload-dev": {
 		"classmap": ["tests/"]
+	},
+	"config": {
+		"platform": {
+			"ext-mongo": "1.6.16"
+		}
 	}
 }

--- a/extension.neon
+++ b/extension.neon
@@ -12,11 +12,11 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-		class: PHPStan\Type\Doctrine\EntityManagerFindDynamicReturnTypeExtension
+		class: PHPStan\Type\Doctrine\ObjectManagerFindDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-		class: PHPStan\Type\Doctrine\EntityManagerGetRepositoryDynamicReturnTypeExtension
+		class: PHPStan\Type\Doctrine\ObjectManagerGetRepositoryDynamicReturnTypeExtension
 		arguments:
 			repositoryClass: %doctrine.repositoryClass%
 		tags:
@@ -26,6 +26,6 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-		class: PHPStan\Type\Doctrine\EntityRepositoryDynamicReturnTypeExtension
+		class: PHPStan\Type\Doctrine\ObjectRepositoryDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/extension.neon
+++ b/extension.neon
@@ -1,6 +1,6 @@
 parameters:
 	doctrine:
-		repositoryClass: Doctrine\ORM\EntityRepository
+		objectManagerLoader: ~
 
 services:
 	-
@@ -17,8 +17,6 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
 		class: PHPStan\Type\Doctrine\ObjectManagerGetRepositoryDynamicReturnTypeExtension
-		arguments:
-			repositoryClass: %doctrine.repositoryClass%
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
@@ -29,3 +27,7 @@ services:
 		class: PHPStan\Type\Doctrine\ObjectRepositoryDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\Type\Doctrine\ObjectMetadataResolver
+		arguments:
+			objectManagerLoader: %doctrine.objectManagerLoader%

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,7 @@ includes:
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+	excludes_analyse:
+		- */tests/*/data/*

--- a/src/Type/Doctrine/EntityManagerFindDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerFindDynamicReturnTypeExtension.php
@@ -43,12 +43,7 @@ class EntityManagerFindDynamicReturnTypeExtension implements \PHPStan\Type\Dynam
 			return $mixedType;
 		}
 
-		$type = new ObjectType($argType->getValue());
-		if ($methodReflection->getName() === 'find') {
-			$type = TypeCombinator::addNull($type);
-		}
-
-		return $type;
+		return TypeCombinator::addNull(new ObjectType($argType->getValue()));
 	}
 
 }

--- a/src/Type/Doctrine/ObjectManagerFindDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/ObjectManagerFindDynamicReturnTypeExtension.php
@@ -11,7 +11,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
-class EntityManagerFindDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+class ObjectManagerFindDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
 	public function getClass(): string

--- a/src/Type/Doctrine/ObjectManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/ObjectManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -10,7 +10,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 
-class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+class ObjectManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
 	/** @var string */
@@ -47,7 +47,7 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 			return new MixedType();
 		}
 
-		return new EntityRepositoryType($argType->getValue(), $this->repositoryClass);
+		return new ObjectRepositoryType($argType->getValue(), $this->repositoryClass);
 	}
 
 }

--- a/src/Type/Doctrine/ObjectManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/ObjectManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -13,12 +13,12 @@ use PHPStan\Type\Type;
 class ObjectManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
-	/** @var string */
-	private $repositoryClass;
+	/** @var ObjectMetadataResolver */
+	private $metadataResolver;
 
-	public function __construct(string $repositoryClass)
+	public function __construct(ObjectMetadataResolver $metadataResolver)
 	{
-		$this->repositoryClass = $repositoryClass;
+		$this->metadataResolver = $metadataResolver;
 	}
 
 	public function getClass(): string
@@ -47,7 +47,14 @@ class ObjectManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 			return new MixedType();
 		}
 
-		return new ObjectRepositoryType($argType->getValue(), $this->repositoryClass);
+		$objectName = $argType->getValue();
+		$repositoryClass = $this->metadataResolver->getRepositoryClass($objectName);
+
+		if ($repositoryClass === null) {
+			return new MixedType();
+		}
+
+		return new ObjectRepositoryType($objectName, $repositoryClass);
 	}
 
 }

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMMetadata;
+use RuntimeException;
+use function file_exists;
+use function is_readable;
+
+final class ObjectMetadataResolver
+{
+
+	/** @var ObjectManager */
+	private $objectManager;
+
+	public function __construct(string $objectManagerLoader)
+	{
+		$this->objectManager = $this->getObjectManager($objectManagerLoader);
+	}
+
+	private function getObjectManager(string $objectManagerLoader): ObjectManager
+	{
+		if (! file_exists($objectManagerLoader) && ! is_readable($objectManagerLoader)) {
+			throw new RuntimeException('Object manager could not be loaded');
+		}
+
+		return require $objectManagerLoader;
+	}
+
+	public function getRepositoryClass(string $className): ?string
+	{
+		$metatada = $this->objectManager->getClassMetadata($className);
+
+		if ($metatada instanceof ORMMetadata) {
+			return $metatada->customRepositoryClassName ?? 'Doctrine\ORM\EntityRepository';
+		}
+
+		if ($metatada instanceof ODMMetadata) {
+			return $metatada->customRepositoryClassName ?? 'Doctrine\ODM\MongoDB\DocumentRepository';
+		}
+
+		return null;
+	}
+
+}

--- a/src/Type/Doctrine/ObjectRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/ObjectRepositoryDynamicReturnTypeExtension.php
@@ -12,12 +12,12 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
-class EntityRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+class ObjectRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
 	public function getClass(): string
 	{
-		return 'Doctrine\ORM\EntityRepository';
+		return 'Doctrine\Common\Persistence\ObjectRepository';
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool
@@ -36,7 +36,7 @@ class EntityRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\Dynami
 	): Type
 	{
 		$calledOnType = $scope->getType($methodCall->var);
-		if (!$calledOnType instanceof EntityRepositoryType) {
+		if (!$calledOnType instanceof ObjectRepositoryType) {
 			return new MixedType();
 		}
 		$methodName = $methodReflection->getName();

--- a/src/Type/Doctrine/ObjectRepositoryType.php
+++ b/src/Type/Doctrine/ObjectRepositoryType.php
@@ -5,7 +5,7 @@ namespace PHPStan\Type\Doctrine;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
 
-class EntityRepositoryType extends ObjectType
+class ObjectRepositoryType extends ObjectType
 {
 
 	/** @var string */

--- a/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
@@ -16,6 +16,7 @@ final class DocumentManagerIntegrationTest extends LevelsTestCase
 			['documentManagerDynamicReturn'],
 			['documentRepositoryDynamicReturn'],
 			['documentManagerMergeReturn'],
+			['customRepositoryUsage'],
 		];
 	}
 

--- a/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ODM;
+
+use PHPStan\Testing\LevelsTestCase;
+
+final class DocumentManagerIntegrationTest extends LevelsTestCase
+{
+
+	/**
+	 * @return string[][]
+	 */
+	public function dataTopics(): array
+	{
+		return [
+			['documentManagerDynamicReturn'],
+			['documentRepositoryDynamicReturn'],
+			['documentManagerMergeReturn'],
+		];
+	}
+
+	public function getDataPath(): string
+	{
+		return __DIR__ . '/data';
+	}
+
+	public function getPhpStanExecutablePath(): string
+	{
+		return __DIR__ . '/../../../vendor/bin/phpstan';
+	}
+
+	public function getPhpStanConfigPath(): ?string
+	{
+		return __DIR__ . '/phpstan.neon';
+	}
+
+}

--- a/tests/DoctrineIntegration/ODM/data/customRepositoryUsage.php
+++ b/tests/DoctrineIntegration/ODM/data/customRepositoryUsage.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ODM\CustomRepositoryUsage;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\DocumentRepository;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var MyRepository
+	 */
+	private $repository;
+
+	public function __construct(DocumentManager $documentManager)
+	{
+		$this->repository = $documentManager->getRepository(MyDocument::class);
+	}
+
+	public function get(): void
+	{
+		$test = $this->repository->get('testing');
+		$test->doSomethingElse();
+	}
+}
+
+/**
+ * @Document(repositoryClass=MyRepository::class)
+ */
+class MyDocument
+{
+	/**
+	 * @Id(strategy="NONE", type="string")
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	public function doSomethingElse(): void
+	{
+	}
+}
+
+class MyRepository extends DocumentRepository
+{
+	public function get(string $id): MyDocument
+	{
+		$document = $this->find($id);
+
+		if ($document === null) {
+			throw new RuntimeException('Not found...');
+		}
+
+		return $document;
+	}
+}

--- a/tests/DoctrineIntegration/ODM/data/documentManagerDynamicReturn.php
+++ b/tests/DoctrineIntegration/ODM/data/documentManagerDynamicReturn.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ODM\DocumentManagerDynamicReturn;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var DocumentManager
+	 */
+	private $documentManager;
+
+	public function __construct(DocumentManager $documentManager)
+	{
+		$this->documentManager = $documentManager;
+	}
+
+	public function findDynamicType(): void
+	{
+		$test = $this->documentManager->find(MyDocument::class, 'blah-123');
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+
+	public function getReferenceDynamicType(): void
+	{
+		$test = $this->documentManager->getReference(MyDocument::class, 'blah-123');
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+
+	public function getPartialReferenceDynamicType(): void
+	{
+		$test = $this->documentManager->getPartialReference(MyDocument::class, 'blah-123');
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+}
+
+/**
+ * @Document()
+ */
+class MyDocument
+{
+	/**
+	 * @Id(strategy="NONE", type="string")
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	public function doSomething(): void
+	{
+	}
+}

--- a/tests/DoctrineIntegration/ODM/data/documentManagerMergeReturn.php
+++ b/tests/DoctrineIntegration/ODM/data/documentManagerMergeReturn.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ODM\DocumentManagerMergeReturn;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+
+class Example
+{
+	/**
+	 * @var DocumentManager
+	 */
+	private $documentManager;
+
+	public function __construct(DocumentManager $documentManager)
+	{
+		$this->documentManager = $documentManager;
+	}
+
+	public function merge(): void
+	{
+		$test = $this->documentManager->merge(new MyDocument());
+		$test->doSomething();
+	}
+}
+
+/**
+ * @Document()
+ */
+class MyDocument
+{
+	/**
+	 * @Id(strategy="NONE", type="string")
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	public function doSomething(): void
+	{
+	}
+}

--- a/tests/DoctrineIntegration/ODM/data/documentRepositoryDynamicReturn.php
+++ b/tests/DoctrineIntegration/ODM/data/documentRepositoryDynamicReturn.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ODM\DocumentRepositoryDynamicReturn;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\DocumentRepository;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var DocumentRepository
+	 */
+	private $repository;
+
+	public function __construct(DocumentManager $documentManager)
+	{
+		$this->repository = $documentManager->getRepository(MyDocument::class);
+	}
+
+	public function findDynamicType(): void
+	{
+		$test = $this->repository->find(1);
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+
+	public function findOneByDynamicType(): void
+	{
+		$test = $this->repository->findOneBy(['blah' => 'testing']);
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+
+	public function findAllDynamicType(): void
+	{
+		$items = $this->repository->findAll();
+
+		foreach ($items as $test) {
+			$test->doSomething();
+		}
+	}
+
+	public function findByDynamicType(): void
+	{
+		$items = $this->repository->findBy(['blah' => 'testing']);
+
+		foreach ($items as $test) {
+			$test->doSomething();
+		}
+	}
+}
+
+/**
+ * @Document()
+ */
+class MyDocument
+{
+	/**
+	 * @Id(strategy="NONE", type="string")
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	public function doSomething(): void
+	{
+	}
+}

--- a/tests/DoctrineIntegration/ODM/document-manager.php
+++ b/tests/DoctrineIntegration/ODM/document-manager.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+
+AnnotationRegistry::registerUniqueLoader('class_exists');
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__);
+$config->setProxyNamespace('PHPstan\Doctrine\OdmProxies');
+$config->setMetadataCacheImpl(new ArrayCache());
+$config->setHydratorDir(__DIR__);
+$config->setHydratorNamespace('PHPstan\Doctrine\OdmHydrators');
+
+$config->setMetadataDriverImpl(
+	new AnnotationDriver(
+		new AnnotationReader(),
+		[__DIR__ . '/data']
+	)
+);
+
+return DocumentManager::create(
+	null,
+	$config
+);

--- a/tests/DoctrineIntegration/ODM/phpstan.neon
+++ b/tests/DoctrineIntegration/ODM/phpstan.neon
@@ -3,4 +3,4 @@ includes:
 
 parameters:
 	doctrine:
-		repositoryClass: Doctrine\ODM\MongoDB\DocumentRepository
+		objectManagerLoader: tests/DoctrineIntegration/ODM/document-manager.php

--- a/tests/DoctrineIntegration/ODM/phpstan.neon
+++ b/tests/DoctrineIntegration/ODM/phpstan.neon
@@ -1,0 +1,6 @@
+includes:
+	- ../../../extension.neon
+
+parameters:
+	doctrine:
+		repositoryClass: Doctrine\ODM\MongoDB\DocumentRepository

--- a/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
@@ -15,6 +15,7 @@ final class EntityManagerIntegrationTest extends LevelsTestCase
 		return [
 			['entityManagerDynamicReturn'],
 			['entityRepositoryDynamicReturn'],
+			['entityManagerMergeReturn'],
 		];
 	}
 

--- a/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
@@ -16,6 +16,7 @@ final class EntityManagerIntegrationTest extends LevelsTestCase
 			['entityManagerDynamicReturn'],
 			['entityRepositoryDynamicReturn'],
 			['entityManagerMergeReturn'],
+			['customRepositoryUsage'],
 		];
 	}
 

--- a/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
@@ -12,7 +12,10 @@ final class EntityManagerIntegrationTest extends LevelsTestCase
 	 */
 	public function dataTopics(): array
 	{
-		return [['entityManagerDynamicReturn']];
+		return [
+			['entityManagerDynamicReturn'],
+			['entityRepositoryDynamicReturn'],
+		];
 	}
 
 	public function getDataPath(): string

--- a/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ORM;
+
+use PHPStan\Testing\LevelsTestCase;
+
+final class EntityManagerIntegrationTest extends LevelsTestCase
+{
+
+	/**
+	 * @return string[][]
+	 */
+	public function dataTopics(): array
+	{
+		return [['entityManagerDynamicReturn']];
+	}
+
+	public function getDataPath(): string
+	{
+		return __DIR__ . '/data';
+	}
+
+	public function getPhpStanExecutablePath(): string
+	{
+		return __DIR__ . '/../../../vendor/bin/phpstan';
+	}
+
+	public function getPhpStanConfigPath(): ?string
+	{
+		return __DIR__ . '/phpstan.neon';
+	}
+
+}

--- a/tests/DoctrineIntegration/ORM/data/customRepositoryUsage.php
+++ b/tests/DoctrineIntegration/ORM/data/customRepositoryUsage.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ORM\CustomRepositoryUsage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping as ORM;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var MyRepository
+	 */
+	private $repository;
+
+	public function __construct(EntityManagerInterface $entityManager)
+	{
+		$this->repository = $entityManager->getRepository(MyEntity::class);
+	}
+
+	public function get(): void
+	{
+		$test = $this->repository->get(1);
+		$test->doSomethingElse();
+	}
+}
+
+/**
+ * @ORM\Entity(repositoryClass=MyRepository::class)
+ */
+class MyEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	public function doSomethingElse(): void
+	{
+	}
+}
+
+class MyRepository extends EntityRepository
+{
+	public function get(int $id): MyEntity
+	{
+		$entity = $this->find($id);
+
+		if ($entity === null) {
+			throw new RuntimeException('Not found...');
+		}
+
+		return $entity;
+	}
+}

--- a/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
@@ -32,12 +32,22 @@ class Example
 	public function getReferenceDynamicType(): void
 	{
 		$test = $this->entityManager->getReference(MyEntity::class, 1);
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
 		$test->doSomething();
 	}
 
 	public function getPartialReferenceDynamicType(): void
 	{
 		$test = $this->entityManager->getPartialReference(MyEntity::class, 1);
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
 		$test->doSomething();
 	}
 }

--- a/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ORM\EntityManagerDynamicReturn;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping as ORM;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var EntityManagerInterface
+	 */
+	private $entityManager;
+
+	public function __construct(EntityManagerInterface $entityManager)
+	{
+		$this->entityManager = $entityManager;
+	}
+
+	public function findDynamicType(): void
+	{
+		$test = $this->entityManager->find(MyEntity::class, 1);
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+
+	public function getReferenceDynamicType(): void
+	{
+		$test = $this->entityManager->getReference(MyEntity::class, 1);
+		$test->doSomething();
+	}
+
+	public function getPartialReferenceDynamicType(): void
+	{
+		$test = $this->entityManager->getPartialReference(MyEntity::class, 1);
+		$test->doSomething();
+	}
+}
+
+/**
+ * @ORM\Entity()
+ */
+class MyEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	public function doSomething(): void
+	{
+	}
+}

--- a/tests/DoctrineIntegration/ORM/data/entityManagerMergeReturn.php
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerMergeReturn.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ORM\EntityManagerMergeReturn;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping as ORM;
+
+class Example
+{
+	/**
+	 * @var EntityManagerInterface
+	 */
+	private $entityManager;
+
+	public function __construct(EntityManagerInterface $entityManager)
+	{
+		$this->entityManager = $entityManager;
+	}
+
+	public function merge(): void
+	{
+		$test = $this->entityManager->merge(new MyEntity());
+		$test->doSomething();
+	}
+}
+
+/**
+ * @ORM\Entity()
+ */
+class MyEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	public function doSomething(): void
+	{
+	}
+}

--- a/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn.php
+++ b/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ORM\EntityRepositoryDynamicReturn;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping as ORM;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var EntityRepository
+	 */
+	private $repository;
+
+	public function __construct(EntityManagerInterface $entityManager)
+	{
+		$this->repository = $entityManager->getRepository(MyEntity::class);
+	}
+
+	public function findDynamicType(): void
+	{
+		$test = $this->repository->find(1);
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+
+	public function findOneByDynamicType(): void
+	{
+		$test = $this->repository->findOneBy(['blah' => 'testing']);
+
+		if ($test === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$test->doSomething();
+	}
+
+	public function findAllDynamicType(): void
+	{
+		$items = $this->repository->findAll();
+
+		foreach ($items as $test) {
+			$test->doSomething();
+		}
+	}
+
+	public function findByDynamicType(): void
+	{
+		$items = $this->repository->findBy(['blah' => 'testing']);
+
+		foreach ($items as $test) {
+			$test->doSomething();
+		}
+	}
+}
+
+/**
+ * @ORM\Entity()
+ */
+class MyEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	public function doSomething(): void
+	{
+	}
+}

--- a/tests/DoctrineIntegration/ORM/entity-manager.php
+++ b/tests/DoctrineIntegration/ORM/entity-manager.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+
+AnnotationRegistry::registerUniqueLoader('class_exists');
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__);
+$config->setProxyNamespace('PHPstan\Doctrine\OrmProxies');
+$config->setMetadataCacheImpl(new ArrayCache());
+
+$config->setMetadataDriverImpl(
+	new AnnotationDriver(
+		new AnnotationReader(),
+		[__DIR__ . '/data']
+	)
+);
+
+return EntityManager::create(
+	[
+		'driver' => 'pdo_sqlite',
+		'memory' => true,
+	],
+	$config
+);

--- a/tests/DoctrineIntegration/ORM/phpstan.neon
+++ b/tests/DoctrineIntegration/ORM/phpstan.neon
@@ -1,0 +1,2 @@
+includes:
+	- ../../../extension.neon

--- a/tests/DoctrineIntegration/ORM/phpstan.neon
+++ b/tests/DoctrineIntegration/ORM/phpstan.neon
@@ -1,2 +1,6 @@
 includes:
 	- ../../../extension.neon
+
+parameters:
+	doctrine:
+		objectManagerLoader: tests/DoctrineIntegration/ORM/entity-manager.php


### PR DESCRIPTION
With this implementation we're able to use the class metadata to retrieve repository information, given the user provides the entity/document manager instance.

Depends on #39 