### PR TITLE
Added custom repository class support

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,6 +1,8 @@
 parameters:
 	doctrine:
 		repositoryClass: Doctrine\ORM\EntityRepository
+		repositoryPattern: /(.*)(Entity)(.*)/
+		repositoryReplace: $1Repository$3Repository
 
 services:
 	-
@@ -19,6 +21,8 @@ services:
 		class: PHPStan\Type\Doctrine\EntityManagerGetRepositoryDynamicReturnTypeExtension
 		arguments:
 			repositoryClass: %doctrine.repositoryClass%
+			repositoryPattern: %doctrine.repositoryPattern%
+			repositoryReplace: %doctrine.repositoryReplace%
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-

--- a/extension.neon
+++ b/extension.neon
@@ -1,8 +1,8 @@
 parameters:
 	doctrine:
 		repositoryClass: Doctrine\ORM\EntityRepository
-		repositoryPattern: /(.*)(Entity)(.*)/
-		repositoryReplace: $1Repository$3Repository
+		repositoryPattern: "/(.*)(Entity)(.*)/"
+		repositoryReplace: "$1Repository$3Repository"
 
 services:
 	-

--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -57,7 +57,7 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 
 		$repositoryClass = preg_replace($this->repositoryPattern, $this->repositoryReplace, $argType->getValue());
 
-		if (!$repositoryClass || !class_exists($repositoryClass)) {
+		if (!is_string($repositoryClass) || !class_exists($repositoryClass)) {
 			$repositoryClass = $this->repositoryClass;
 		}
 

--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -57,7 +57,17 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 
 		$repositoryClass = preg_replace($this->repositoryPattern, $this->repositoryReplace, $argType->getValue());
 
-		if (!is_string($repositoryClass) || !class_exists($repositoryClass)) {
+		if (!is_string($repositoryClass)) {
+			throw new \InvalidArgumentException(
+				sprintf(
+					'Given repositoryPattern("%s") or repositoryReplace("%s") is invalid.',
+					$this->repositoryPattern,
+					$this->repositoryReplace
+				)
+			);
+		}
+
+		if (!class_exists($repositoryClass)) {
 			$repositoryClass = $this->repositoryClass;
 		}
 

--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -59,7 +59,7 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 
 		$repositoryClass = preg_replace($this->repositoryPattern, $this->repositoryReplace, $argType->getValue());
 
-		if (!class_exists($repositoryClass)) {
+		if (!$repositoryClass || !class_exists($repositoryClass)) {
 			$repositoryClass = $this->repositoryClass;
 		}
 

--- a/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityManagerGetRepositoryDynamicReturnTypeExtension.php
@@ -50,9 +50,7 @@ class EntityManagerGetRepositoryDynamicReturnTypeExtension implements \PHPStan\T
 				$methodReflection->getVariants()
 			)->getReturnType();
 		}
-
 		$argType = $scope->getType($methodCall->args[0]->value);
-
 		if (!$argType instanceof ConstantStringType) {
 			return new MixedType();
 		}


### PR DESCRIPTION
This will check if a custom repository exists in the given folder. By default it search in the doctrine Repository folder which is normally used when generating entities. Its not the cleanest but think the most efficient way as it not need to parse the doctrine configuration and also don't requires pdo_sqlite as in the current open PR #18 