### PR TITLE
Use real object managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,29 @@ This extension provides following features:
 * Provides correct return type for `Doctrine\ORM\EntityManager::find`, `getReference` and `getPartialReference` when `Foo::class` entity class name is provided as the first argument
 * Adds missing `matching` method on `Doctrine\Common\Collections\Collection`. This can be turned off by setting `parameters.doctrine.allCollectionsSelectable` to `false`.
 
-This extension does not yet support custom `repositoryClass` specified for each entity class. However, if your repositories have a common base class, you can configure it in your `phpstan.neon` and PHPStan will see additional methods you define in it:
+If your repositories have a common base class, you can configure it in your `phpstan.neon` and PHPStan will see additional methods you define in it:
 
-```
+```neon
 parameters:
 	doctrine:
 		repositoryClass: MyApp\Doctrine\BetterEntityRepository
+```
+
+Alternatively, you can provide your object manager and all custom repositories will be loaded
+
+```neon
+parameters:
+	doctrine:
+		objectManagerLoader: tests/object-manager.php
+```
+
+For example, in a Symfony project, `object-manager.php` would look something like this:
+
+```php
+require dirname(__DIR__).'/../config/bootstrap.php';
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel->boot();
+return $kernel->getContainer()->get('doctrine')->getManager();
 ```
 
 ## Usage

--- a/extension.neon
+++ b/extension.neon
@@ -2,6 +2,7 @@ parameters:
 	doctrine:
 		repositoryClass: Doctrine\ORM\EntityRepository
 		allCollectionsSelectable: true
+		objectManagerLoader: ~
 
 conditionalTags:
 	PHPStan\Reflection\Doctrine\DoctrineSelectableClassReflectionExtension:
@@ -20,8 +21,6 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
 		class: PHPStan\Type\Doctrine\ObjectManagerGetRepositoryDynamicReturnTypeExtension
-		arguments:
-			repositoryClass: %doctrine.repositoryClass%
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
@@ -38,3 +37,7 @@ services:
 			repositoryClass: %doctrine.repositoryClass%
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\Type\Doctrine\ObjectMetadataResolver
+		arguments:
+			objectManagerLoader: %doctrine.objectManagerLoader%

--- a/extension.neon
+++ b/extension.neon
@@ -2,7 +2,7 @@ parameters:
 	doctrine:
 		repositoryClass: Doctrine\ORM\EntityRepository
 		allCollectionsSelectable: true
-		objectManagerLoader: ~
+		objectManagerLoader: null
 
 conditionalTags:
 	PHPStan\Reflection\Doctrine\DoctrineSelectableClassReflectionExtension:
@@ -33,11 +33,10 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
 		class: PHPStan\Type\Doctrine\ManagerRegistryGetRepositoryDynamicReturnTypeExtension
-		arguments:
-			repositoryClass: %doctrine.repositoryClass%
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
 		class: PHPStan\Type\Doctrine\ObjectMetadataResolver
 		arguments:
 			objectManagerLoader: %doctrine.objectManagerLoader%
+			repositoryClass: %doctrine.repositoryClass%

--- a/extension.neon
+++ b/extension.neon
@@ -1,6 +1,6 @@
 parameters:
 	doctrine:
-		repositoryClass: Doctrine\ORM\EntityRepository
+		repositoryClass: null
 		allCollectionsSelectable: true
 		objectManagerLoader: null
 

--- a/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
@@ -13,12 +13,12 @@ use PHPStan\Type\Type;
 abstract class GetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
-	/** @var string */
-	private $repositoryClass;
+	/** @var ObjectMetadataResolver */
+	private $metadataResolver;
 
-	public function __construct(string $repositoryClass)
+	public function __construct(ObjectMetadataResolver $metadataResolver)
 	{
-		$this->repositoryClass = $repositoryClass;
+		$this->metadataResolver = $metadataResolver;
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool
@@ -42,7 +42,14 @@ abstract class GetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\
 			return new MixedType();
 		}
 
-		return new ObjectRepositoryType($argType->getValue(), $this->repositoryClass);
+		$objectName = $argType->getValue();
+		$repositoryClass = $this->metadataResolver->getRepositoryClass($objectName);
+
+		if ($repositoryClass === null) {
+			return new MixedType();
+		}
+
+		return new ObjectRepositoryType($objectName, $repositoryClass);
 	}
 
 }

--- a/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
@@ -45,10 +45,6 @@ abstract class GetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\
 		$objectName = $argType->getValue();
 		$repositoryClass = $this->metadataResolver->getRepositoryClass($objectName);
 
-		if ($repositoryClass === null) {
-			return new MixedType();
-		}
-
 		return new ObjectRepositoryType($objectName, $repositoryClass);
 	}
 

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata as ORMMetadata;
+use RuntimeException;
+use function file_exists;
+use function is_readable;
+
+final class ObjectMetadataResolver
+{
+
+	/** @var ObjectManager */
+	private $objectManager;
+
+	public function __construct(string $objectManagerLoader)
+	{
+		$this->objectManager = $this->getObjectManager($objectManagerLoader);
+	}
+
+	private function getObjectManager(string $objectManagerLoader): ObjectManager
+	{
+		if (! file_exists($objectManagerLoader) && ! is_readable($objectManagerLoader)) {
+			throw new RuntimeException('Object manager could not be loaded');
+		}
+
+		return require $objectManagerLoader;
+	}
+
+	public function getRepositoryClass(string $className): ?string
+	{
+		$metadata = $this->objectManager->getClassMetadata($className);
+
+		if ($metadata instanceof ORMMetadata) {
+			return $metadata->customRepositoryClassName ?? 'Doctrine\ORM\EntityRepository';
+		}
+
+		if ($metadata instanceof ODMMetadata) {
+			return $metadata->customRepositoryClassName ?? 'Doctrine\ODM\MongoDB\DocumentRepository';
+		}
+
+		return null;
+	}
+
+}

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -12,12 +12,18 @@ use function is_readable;
 final class ObjectMetadataResolver
 {
 
-	/** @var ObjectManager */
+	/** @var ?ObjectManager */
 	private $objectManager;
 
-	public function __construct(string $objectManagerLoader)
+	/** @var string */
+	private $repositoryClass;
+
+	public function __construct(?string $objectManagerLoader, string $repositoryClass)
 	{
-		$this->objectManager = $this->getObjectManager($objectManagerLoader);
+		if ($objectManagerLoader !== null) {
+			$this->objectManager = $this->getObjectManager($objectManagerLoader);
+		}
+		$this->repositoryClass = $repositoryClass;
 	}
 
 	private function getObjectManager(string $objectManagerLoader): ObjectManager
@@ -29,8 +35,12 @@ final class ObjectMetadataResolver
 		return require $objectManagerLoader;
 	}
 
-	public function getRepositoryClass(string $className): ?string
+	public function getRepositoryClass(string $className): string
 	{
+		if ($this->objectManager === null) {
+			return $this->repositoryClass;
+		}
+
 		$metadata = $this->objectManager->getClassMetadata($className);
 
 		if ($metadata instanceof ORMMetadata) {
@@ -41,7 +51,7 @@ final class ObjectMetadataResolver
 			return $metadata->customRepositoryClassName ?? 'Doctrine\ODM\MongoDB\DocumentRepository';
 		}
 
-		return null;
+		return $this->repositoryClass;
 	}
 
 }

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -3,8 +3,6 @@
 namespace PHPStan\Type\Doctrine;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMMetadata;
-use Doctrine\ORM\Mapping\ClassMetadata as ORMMetadata;
 use RuntimeException;
 use function file_exists;
 use function is_readable;
@@ -32,7 +30,12 @@ final class ObjectMetadataResolver
 		}
 	}
 
-	private function getObjectManager(string $objectManagerLoader): ObjectManager
+	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
+	 * @param string $objectManagerLoader
+	 * @return ObjectManager
+	 */
+	private function getObjectManager(string $objectManagerLoader)
 	{
 		if (! file_exists($objectManagerLoader) && ! is_readable($objectManagerLoader)) {
 			throw new RuntimeException('Object manager could not be loaded');
@@ -49,12 +52,18 @@ final class ObjectMetadataResolver
 
 		$metadata = $this->objectManager->getClassMetadata($className);
 
-		if ($metadata instanceof ORMMetadata) {
-			return $metadata->customRepositoryClassName ?? $this->repositoryClass;
+		$ormMetadataClass = 'Doctrine\ORM\Mapping\ClassMetadata';
+		if ($metadata instanceof $ormMetadataClass) {
+			/** @var \Doctrine\ORM\Mapping\ClassMetadata $ormMetadata */
+			$ormMetadata = $metadata;
+			return $ormMetadata->customRepositoryClassName ?? $this->repositoryClass;
 		}
 
-		if ($metadata instanceof ODMMetadata) {
-			return $metadata->customRepositoryClassName ?? $this->repositoryClass;
+		$odmMetadataClass = 'Doctrine\ODM\MongoDB\Mapping\ClassMetadata';
+		if ($metadata instanceof $odmMetadataClass) {
+			/** @var \Doctrine\ODM\MongoDB\Mapping\ClassMetadata $odmMetadata */
+			$odmMetadata = $metadata;
+			return $odmMetadata->customRepositoryClassName ?? $this->repositoryClass;
 		}
 
 		return $this->repositoryClass;

--- a/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
@@ -16,6 +16,7 @@ final class DocumentManagerIntegrationTest extends LevelsTestCase
 			['documentManagerDynamicReturn'],
 			['documentRepositoryDynamicReturn'],
 			['documentManagerMergeReturn'],
+			['customRepositoryUsage'],
 		];
 	}
 

--- a/tests/DoctrineIntegration/ODM/data/customRepositoryUsage-2.json
+++ b/tests/DoctrineIntegration/ODM/data/customRepositoryUsage-2.json
@@ -1,0 +1,7 @@
+[
+    {
+        "message": "Call to an undefined method PHPStan\\DoctrineIntegration\\ODM\\CustomRepositoryUsage\\MyRepository::nonexistant().",
+        "line": 31,
+        "ignorable": true
+    }
+]

--- a/tests/DoctrineIntegration/ODM/data/customRepositoryUsage.php
+++ b/tests/DoctrineIntegration/ODM/data/customRepositoryUsage.php
@@ -25,6 +25,11 @@ class Example
 		$test = $this->repository->get('testing');
 		$test->doSomethingElse();
 	}
+
+	public function nonexistant(): void
+	{
+		$this->repository->nonexistant();
+	}
 }
 
 /**

--- a/tests/DoctrineIntegration/ODM/data/customRepositoryUsage.php
+++ b/tests/DoctrineIntegration/ODM/data/customRepositoryUsage.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ODM\CustomRepositoryUsage;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\DocumentRepository;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var MyRepository
+	 */
+	private $repository;
+
+	public function __construct(DocumentManager $documentManager)
+	{
+		$this->repository = $documentManager->getRepository(MyDocument::class);
+	}
+
+	public function get(): void
+	{
+		$test = $this->repository->get('testing');
+		$test->doSomethingElse();
+	}
+}
+
+/**
+ * @Document(repositoryClass=MyRepository::class)
+ */
+class MyDocument
+{
+	/**
+	 * @Id(strategy="NONE", type="string")
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	public function doSomethingElse(): void
+	{
+	}
+}
+
+class MyRepository extends DocumentRepository
+{
+	public function get(string $id): MyDocument
+	{
+		$document = $this->find($id);
+
+		if ($document === null) {
+			throw new RuntimeException('Not found...');
+		}
+
+		return $document;
+	}
+}

--- a/tests/DoctrineIntegration/ODM/document-manager.php
+++ b/tests/DoctrineIntegration/ODM/document-manager.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+
+AnnotationRegistry::registerUniqueLoader('class_exists');
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__);
+$config->setProxyNamespace('PHPstan\Doctrine\OdmProxies');
+$config->setMetadataCacheImpl(new ArrayCache());
+$config->setHydratorDir(__DIR__);
+$config->setHydratorNamespace('PHPstan\Doctrine\OdmHydrators');
+
+$config->setMetadataDriverImpl(
+	new AnnotationDriver(
+		new AnnotationReader(),
+		[__DIR__ . '/data']
+	)
+);
+
+return DocumentManager::create(
+	null,
+	$config
+);

--- a/tests/DoctrineIntegration/ODM/phpstan.neon
+++ b/tests/DoctrineIntegration/ODM/phpstan.neon
@@ -3,4 +3,4 @@ includes:
 
 parameters:
 	doctrine:
-		repositoryClass: Doctrine\ODM\MongoDB\DocumentRepository
+		objectManagerLoader: tests/DoctrineIntegration/ODM/document-manager.php

--- a/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
@@ -16,6 +16,7 @@ final class EntityManagerIntegrationTest extends LevelsTestCase
 			['entityManagerDynamicReturn'],
 			['entityRepositoryDynamicReturn'],
 			['entityManagerMergeReturn'],
+			['customRepositoryUsage'],
 		];
 	}
 

--- a/tests/DoctrineIntegration/ORM/data/customRepositoryUsage-2.json
+++ b/tests/DoctrineIntegration/ORM/data/customRepositoryUsage-2.json
@@ -1,0 +1,7 @@
+[
+    {
+        "message": "Call to an undefined method PHPStan\\DoctrineIntegration\\ORM\\CustomRepositoryUsage\\MyRepository::nonexistant().",
+        "line": 30,
+        "ignorable": true
+    }
+]

--- a/tests/DoctrineIntegration/ORM/data/customRepositoryUsage.php
+++ b/tests/DoctrineIntegration/ORM/data/customRepositoryUsage.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DoctrineIntegration\ORM\CustomRepositoryUsage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping as ORM;
+use RuntimeException;
+
+class Example
+{
+	/**
+	 * @var MyRepository
+	 */
+	private $repository;
+
+	public function __construct(EntityManagerInterface $entityManager)
+	{
+		$this->repository = $entityManager->getRepository(MyEntity::class);
+	}
+
+	public function get(): void
+	{
+		$test = $this->repository->get(1);
+		$test->doSomethingElse();
+	}
+}
+
+/**
+ * @ORM\Entity(repositoryClass=MyRepository::class)
+ */
+class MyEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	public function doSomethingElse(): void
+	{
+	}
+}
+
+class MyRepository extends EntityRepository
+{
+	public function get(int $id): MyEntity
+	{
+		$entity = $this->find($id);
+
+		if ($entity === null) {
+			throw new RuntimeException('Not found...');
+		}
+
+		return $entity;
+	}
+}

--- a/tests/DoctrineIntegration/ORM/data/customRepositoryUsage.php
+++ b/tests/DoctrineIntegration/ORM/data/customRepositoryUsage.php
@@ -24,6 +24,11 @@ class Example
 		$test = $this->repository->get(1);
 		$test->doSomethingElse();
 	}
+
+	public function nonexistant(): void
+	{
+		$this->repository->nonexistant();
+	}
 }
 
 /**

--- a/tests/DoctrineIntegration/ORM/entity-manager.php
+++ b/tests/DoctrineIntegration/ORM/entity-manager.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+
+AnnotationRegistry::registerUniqueLoader('class_exists');
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__);
+$config->setProxyNamespace('PHPstan\Doctrine\OrmProxies');
+$config->setMetadataCacheImpl(new ArrayCache());
+
+$config->setMetadataDriverImpl(
+	new AnnotationDriver(
+		new AnnotationReader(),
+		[__DIR__ . '/data']
+	)
+);
+
+return EntityManager::create(
+	[
+		'driver' => 'pdo_sqlite',
+		'memory' => true,
+	],
+	$config
+);

--- a/tests/DoctrineIntegration/ORM/phpstan.neon
+++ b/tests/DoctrineIntegration/ORM/phpstan.neon
@@ -1,2 +1,6 @@
 includes:
 	- ../../../extension.neon
+
+parameters:
+	doctrine:
+		objectManagerLoader: tests/DoctrineIntegration/ORM/entity-manager.php


### PR DESCRIPTION
#40, rebased on #48

as in the original, with this implementation we're able to use the class metadata to retrieve repository information, given the user provides the entity/document manager instance.

Additionally, will use default `repositoryClass` when no `objectManagerLoader` is provided.