### PR TITLE
Do not error if a non-field findByX method exists

### DIFF
--- a/src/Rules/Doctrine/ORM/MagicRepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/MagicRepositoryMethodCallRule.php
@@ -78,6 +78,11 @@ class MagicRepositoryMethodCallRule implements Rule
 			return [];
 		}
 
+		$repositoryReflectionClass = new \ReflectionClass($calledOnType->getClassName());
+		if ($repositoryReflectionClass->hasMethod($methodName)) {
+			return [];
+		}
+
 		return [sprintf(
 			'Call to method %s::%s() - entity %s does not have a field named $%s.',
 			$calledOnType->describe(VerbosityLevel::typeOnly()),

--- a/src/Rules/Doctrine/ORM/MagicRepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/MagicRepositoryMethodCallRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Doctrine\ORM;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\Doctrine\ObjectMetadataResolver;
 use PHPStan\Type\Doctrine\ObjectRepositoryType;
@@ -15,9 +16,13 @@ class MagicRepositoryMethodCallRule implements Rule
 	/** @var ObjectMetadataResolver */
 	private $objectMetadataResolver;
 
-	public function __construct(ObjectMetadataResolver $objectMetadataResolver)
+	/** @var Broker */
+	private $broker;
+
+	public function __construct(ObjectMetadataResolver $objectMetadataResolver, Broker $broker)
 	{
 		$this->objectMetadataResolver = $objectMetadataResolver;
+		$this->broker = $broker;
 	}
 
 	public function getNodeType(): string
@@ -78,8 +83,8 @@ class MagicRepositoryMethodCallRule implements Rule
 			return [];
 		}
 
-		$repositoryReflectionClass = new \ReflectionClass($calledOnType->getClassName());
-		if ($repositoryReflectionClass->hasMethod($methodName)) {
+		$repositoryReflectionClass = $this->broker->getClass($calledOnType->getClassName());
+		if ($repositoryReflectionClass->hasNativeMethod($methodName)) {
 			return [];
 		}
 

--- a/tests/Rules/Doctrine/ORM/MagicRepositoryMethodCallRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/MagicRepositoryMethodCallRuleTest.php
@@ -27,20 +27,32 @@ class MagicRepositoryMethodCallRuleTest extends RuleTestCase
 				25,
 			],
 			[
-				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneByTransient() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
-				34,
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findByCustomMethod() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $customMethod.',
+				26,
 			],
 			[
-				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneByNonexistent() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneByTransient() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
 				35,
 			],
 			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneByNonexistent() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				36,
+			],
+			[
 				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::countByTransient() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
-				44,
+				45,
 			],
 			[
 				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::countByNonexistent() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
-				45,
+				46,
+			],
+			[
+				'Call to method PHPStan\Rules\Doctrine\ORM\TestRepository<PHPStan\Rules\Doctrine\ORM\MySecondEntity>::findByTransient() - entity PHPStan\Rules\Doctrine\ORM\MySecondEntity does not have a field named $transient.',
+				55,
+			],
+			[
+				'Call to method PHPStan\Rules\Doctrine\ORM\TestRepository<PHPStan\Rules\Doctrine\ORM\MySecondEntity>::findByNonexistent() - entity PHPStan\Rules\Doctrine\ORM\MySecondEntity does not have a field named $nonexistent.',
+				56,
 			],
 		]);
 	}

--- a/tests/Rules/Doctrine/ORM/MagicRepositoryMethodCallRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/MagicRepositoryMethodCallRuleTest.php
@@ -12,7 +12,9 @@ class MagicRepositoryMethodCallRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new MagicRepositoryMethodCallRule(new ObjectMetadataResolver(__DIR__ . '/entity-manager.php', null));
+		$broker = $this->createBroker();
+
+		return new MagicRepositoryMethodCallRule(new ObjectMetadataResolver(__DIR__ . '/entity-manager.php', null), $broker);
 	}
 
 	public function testRule(): void

--- a/tests/Rules/Doctrine/ORM/data/MySecondEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/MySecondEntity.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="PHPStan\Rules\Doctrine\ORM\TestRepository")
+ */
+class MySecondEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @var string
+	 * @ORM\Column(type="string")
+	 */
+	private $title;
+
+	/**
+	 * @var string
+	 */
+	private $transient;
+
+}

--- a/tests/Rules/Doctrine/ORM/data/dql.php
+++ b/tests/Rules/Doctrine/ORM/data/dql.php
@@ -62,4 +62,9 @@ DQL
 		)->getResult();
 	}
 
+    public function findByCustomMethod(): array
+    {
+        return [];
+    }
+
 }

--- a/tests/Rules/Doctrine/ORM/data/magic-repository.php
+++ b/tests/Rules/Doctrine/ORM/data/magic-repository.php
@@ -23,6 +23,7 @@ class MagicRepositoryCalls
 		$entityRepository->findByTitle('test');
 		$entityRepository->findByTransient('test');
 		$entityRepository->findByNonexistent('test');
+		$entityRepository->findByCustomMethod();
 	}
 
 	public function doFindOneBy(): void
@@ -45,4 +46,14 @@ class MagicRepositoryCalls
 		$entityRepository->countByNonexistent('test');
 	}
 
+	public function doFindByWithRepository(): void
+	{
+		$entityRepository = $this->entityManager->getRepository(MySecondEntity::class);
+		$entityRepository->findBy(['id' => 1]);
+		$entityRepository->findById(1);
+		$entityRepository->findByTitle('test');
+		$entityRepository->findByTransient('test');
+		$entityRepository->findByNonexistent('test');
+		$entityRepository->findByCustomMethod();
+	}
 }


### PR DESCRIPTION
Do not generate an error if a custom findByX (or findOneByX, countByX) method exists but X is not a field in the entity class.

This should fix #52 