### PR TITLE
Tests: use PHPStan binary directly

### DIFF
--- a/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ODM/DocumentManagerIntegrationTest.php
@@ -27,7 +27,7 @@ final class DocumentManagerIntegrationTest extends LevelsTestCase
 
 	public function getPhpStanExecutablePath(): string
 	{
-		return __DIR__ . '/../../../vendor/bin/phpstan';
+		return __DIR__ . '/../../../vendor/phpstan/phpstan/bin/phpstan';
 	}
 
 	public function getPhpStanConfigPath(): ?string

--- a/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
+++ b/tests/DoctrineIntegration/ORM/EntityManagerIntegrationTest.php
@@ -28,7 +28,7 @@ final class EntityManagerIntegrationTest extends LevelsTestCase
 
 	public function getPhpStanExecutablePath(): string
 	{
-		return __DIR__ . '/../../../vendor/bin/phpstan';
+		return __DIR__ . '/../../../vendor/phpstan/phpstan/bin/phpstan';
 	}
 
 	public function getPhpStanConfigPath(): ?string

--- a/tests/DoctrineIntegration/Persistence/ManagerRegistryIntegrationTest.php
+++ b/tests/DoctrineIntegration/Persistence/ManagerRegistryIntegrationTest.php
@@ -24,7 +24,7 @@ final class ManagerRegistryIntegrationTest extends LevelsTestCase
 
 	public function getPhpStanExecutablePath(): string
 	{
-		return __DIR__ . '/../../../vendor/bin/phpstan';
+		return __DIR__ . '/../../../vendor/phpstan/phpstan/bin/phpstan';
 	}
 
 	public function getPhpStanConfigPath(): ?string


### PR DESCRIPTION
On Windows `vendor/bin/phpstan` contains some code for Cygwin, which is not understood when ran directly with PHP binary