### PR TITLE
More verbose exception when unable to read objectManagerLoader file

### DIFF
--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -35,7 +35,7 @@ final class ObjectMetadataResolver
 			!file_exists($objectManagerLoader)
 			|| !is_readable($objectManagerLoader)
 		) {
-			throw new \PHPStan\ShouldNotHappenException('Object manager could not be loaded');
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unable to load ObjectManager from "%s"', $objectManagerLoader));
 		}
 
 		return require $objectManagerLoader;


### PR DESCRIPTION
I'm not too sure about the `ShouldNotHappenException` as this can happen often, but that's a different topic :)