### PR TITLE
Enhancement: Run ergebnis/composer-normalize in check target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,7 @@
 		composer,
 		lint,
 		cs,
+		composer-normalize-check,
 		tests,
 		phpstan
 	"/>
@@ -17,6 +18,31 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-check">
+		<exec
+			executable="composer"
+			logoutput="true"
+			passthru="true"
+			checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
+			<arg value="--dry-run"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-fix">
+		<exec
+			executable="composer"
+			logoutput="true"
+			passthru="true"
+			checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,42 @@
 {
 	"name": "phpstan/phpstan-doctrine",
-	"description": "Doctrine extensions for PHPStan",
 	"type": "phpstan-extension",
-	"license": ["MIT"],
-	"minimum-stability": "dev",
-	"prefer-stable": true,
+	"description": "Doctrine extensions for PHPStan",
+	"license": [
+		"MIT"
+	],
+	"require": {
+		"php": "~7.1",
+		"nikic/php-parser": "^4.0",
+		"phpstan/phpstan": "^0.12.3"
+	},
+	"conflict": {
+		"doctrine/collections": "<1.0",
+		"doctrine/common": "<2.7",
+		"doctrine/mongodb-odm": "<1.2",
+		"doctrine/orm": "<2.5"
+	},
+	"require-dev": {
+		"consistence/coding-standard": "^3.0.1",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+		"doctrine/collections": "^1.0",
+		"doctrine/common": "^2.7",
+		"doctrine/mongodb-odm": "^1.2",
+		"doctrine/orm": "^2.5",
+		"ergebnis/composer-normalize": "^2.0.2",
+		"jakub-onderka/php-parallel-lint": "^1.0",
+		"phing/phing": "^2.16.0",
+		"phpstan/phpstan-phpunit": "^0.12",
+		"phpstan/phpstan-strict-rules": "^0.12",
+		"phpunit/phpunit": "^7.0",
+		"ramsey/uuid-doctrine": "^1.5.0",
+		"slevomat/coding-standard": "^4.5.2"
+	},
+	"config": {
+		"platform": {
+			"ext-mongo": "1.6.16"
+		}
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.12-dev"
@@ -16,44 +48,16 @@
 			]
 		}
 	},
-	"require": {
-		"php": "~7.1",
-		"phpstan/phpstan": "^0.12.3",
-		"nikic/php-parser": "^4.0"
-	},
-	"require-dev": {
-		"consistence/coding-standard": "^3.0.1",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-		"jakub-onderka/php-parallel-lint": "^1.0",
-		"phing/phing": "^2.16.0",
-		"phpstan/phpstan-phpunit": "^0.12",
-		"phpstan/phpstan-strict-rules": "^0.12",
-		"phpunit/phpunit": "^7.0",
-		"ramsey/uuid-doctrine": "^1.5.0",
-		"slevomat/coding-standard": "^4.5.2",
-		"doctrine/common": "^2.7",
-		"doctrine/orm": "^2.5",
-		"doctrine/collections": "^1.0",
-		"doctrine/mongodb-odm": "^1.2",
-		"ergebnis/composer-normalize": "^2.0.2"
-	},
-	"conflict": {
-		"doctrine/common": "<2.7",
-		"doctrine/orm": "<2.5",
-		"doctrine/collections": "<1.0",
-		"doctrine/mongodb-odm": "<1.2"
-	},
 	"autoload": {
 		"psr-4": {
 			"PHPStan\\": "src/"
 		}
 	},
 	"autoload-dev": {
-		"classmap": ["tests/"]
+		"classmap": [
+			"tests/"
+		]
 	},
-	"config": {
-		"platform": {
-			"ext-mongo": "1.6.16"
-		}
-	}
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
 		"doctrine/common": "^2.7",
 		"doctrine/orm": "^2.5",
 		"doctrine/collections": "^1.0",
-		"doctrine/mongodb-odm": "^1.2"
+		"doctrine/mongodb-odm": "^1.2",
+		"ergebnis/composer-normalize": "^2.0.2"
 	},
 	"conflict": {
 		"doctrine/common": "<2.7",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
 	"config": {
 		"platform": {
 			"ext-mongo": "1.6.16"
-		}
+		},
+		"sort-packages": true
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
This PR

* [x] runs `ergebnis/composer-normalize` with the `--dry-run` option in the `check` target
* [x] runs `composer normalize`
* [x] keeps packages sorted in `composer.json`