### PR TITLE
README: ReflectionDescriptor should use 'factory' instead of 'class'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,6 @@ services:
 
 	# in case you are using the ReflectionDescriptor
 	-
-		class: PHPStan\Type\Doctrine\Descriptors\ReflectionDescriptor('MyApp\MyCustomTypeName')
+		factory: PHPStan\Type\Doctrine\Descriptors\ReflectionDescriptor('MyApp\MyCustomTypeName')
 		tags: [phpstan.doctrine.typeDescriptor]
 ```


### PR DESCRIPTION
Otherwise there is a deprecation reported: Service '0': option 'class' should be changed to 'factory'