### PR TITLE
GetRepositoryDynamicReturnTypeExtension: improved return type when argument is not recognized

### DIFF
--- a/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
@@ -9,7 +9,6 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
@@ -60,12 +59,16 @@ class GetRepositoryDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMe
 		} elseif ($argType instanceof GenericClassStringType) {
 			$classType = $argType->getGenericType();
 			if (!$classType instanceof TypeWithClassName) {
-				return new MixedType();
+				return ParametersAcceptorSelector::selectSingle(
+					$methodReflection->getVariants()
+				)->getReturnType();
 			}
 
 			$objectName = $classType->getClassName();
 		} else {
-			return new MixedType();
+			return ParametersAcceptorSelector::selectSingle(
+				$methodReflection->getVariants()
+			)->getReturnType();
 		}
 
 		$repositoryClass = $this->metadataResolver->getRepositoryClass($objectName);

--- a/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn-2.json
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn-2.json
@@ -13,5 +13,10 @@
         "message": "Call to an undefined method PHPStan\\DoctrineIntegration\\ORM\\EntityManagerDynamicReturn\\MyEntity::doSomethingElse().",
         "line": 54,
         "ignorable": true
+    },
+    {
+        "message": "Call to an undefined method Doctrine\\Persistence\\ObjectRepository<T>::unknownMethod().",
+        "line": 64,
+        "ignorable": true
     }
 ]

--- a/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn-2.json
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn-2.json
@@ -15,7 +15,7 @@
         "ignorable": true
     },
     {
-        "message": "Call to an undefined method Doctrine\\Persistence\\ObjectRepository<T>::unknownMethod().",
+        "message": "Call to an undefined method Doctrine\\Persistence\\ObjectRepository<object>::unknownMethod().",
         "line": 64,
         "ignorable": true
     }

--- a/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn-7.json
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn-7.json
@@ -1,0 +1,7 @@
+[
+    {
+        "message": "Call to an undefined method object::unknownMethod().",
+        "line": 71,
+        "ignorable": true
+    }
+]

--- a/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
@@ -62,6 +62,13 @@ class Example
 		$repository = $this->entityManager->getRepository($entityName);
 		$repository->getClassName();
 		$repository->unknownMethod();
+		$entity = $repository->find(1);
+
+		if ($entity === null) {
+			throw new RuntimeException('Sorry, but no...');
+		}
+
+		$entity->unknownMethod();
 	}
 }
 

--- a/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
+++ b/tests/DoctrineIntegration/ORM/data/entityManagerDynamicReturn.php
@@ -53,6 +53,16 @@ class Example
 		$test->doSomething();
 		$test->doSomethingElse();
 	}
+
+	/**
+	 * @param class-string $entityName
+	 */
+	public function doSomethingWithRepository(string $entityName): void
+	{
+		$repository = $this->entityManager->getRepository($entityName);
+		$repository->getClassName();
+		$repository->unknownMethod();
+	}
 }
 
 /**


### PR DESCRIPTION
Previously this bug hasn't been detected:

```php
	/**
	 * @param class-string $entityName
	 */
	public function doSomethingWithEntity(string $entityName): void
	{
		$repository = $this->entityManager->getRepository($entityName);
		$repository->createQueryBuilder('a')->unknownMethod(); // bug
```