### PR TITLE
Support ORM's embeddables

### DIFF
--- a/src/Rules/Doctrine/ORM/EntityColumnRule.php
+++ b/src/Rules/Doctrine/ORM/EntityColumnRule.php
@@ -64,9 +64,6 @@ class EntityColumnRule implements Rule
 		}
 
 		$className = $class->getName();
-		if ($objectManager->getMetadataFactory()->isTransient($className)) {
-			return [];
-		}
 
 		try {
 			$metadata = $objectManager->getClassMetadata($className);

--- a/src/Rules/Doctrine/ORM/EntityEmbeddableRule.php
+++ b/src/Rules/Doctrine/ORM/EntityEmbeddableRule.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MissingPropertyFromReflectionException;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Stmt\PropertyProperty>
+ */
+class EntityEmbeddableRule implements Rule
+{
+
+	/** @var \PHPStan\Type\Doctrine\ObjectMetadataResolver */
+	private $objectMetadataResolver;
+
+	public function __construct(ObjectMetadataResolver $objectMetadataResolver)
+	{
+		$this->objectMetadataResolver = $objectMetadataResolver;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\PropertyProperty::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$class = $scope->getClassReflection();
+		if ($class === null) {
+			return [];
+		}
+
+		$objectManager = $this->objectMetadataResolver->getObjectManager();
+		if ($objectManager === null) {
+			return [];
+		}
+
+		$className = $class->getName();
+
+		try {
+			$metadata = $objectManager->getClassMetadata($className);
+		} catch (\Doctrine\ORM\Mapping\MappingException $e) {
+			return [];
+		}
+
+		$classMetadataInfo = 'Doctrine\ORM\Mapping\ClassMetadataInfo';
+		if (!$metadata instanceof $classMetadataInfo) {
+			return [];
+		}
+
+		$propertyName = (string) $node->name;
+		try {
+			$property = $class->getNativeProperty($propertyName);
+		} catch (MissingPropertyFromReflectionException $e) {
+			return [];
+		}
+
+		if (!isset($metadata->embeddedClasses[$propertyName])) {
+			return [];
+		}
+
+		$errors = [];
+		$embeddedClass = $metadata->embeddedClasses[$propertyName];
+		$propertyWritableType = $property->getWritableType();
+		$accordingToMapping = new ObjectType($embeddedClass['class']);
+		if (!TypeCombinator::removeNull($propertyWritableType)->equals($accordingToMapping)) {
+			$errors[] = sprintf(
+				'Property %s::$%s type mapping mismatch: mapping specifies %s but property expects %s.',
+				$class->getName(),
+				$propertyName,
+				$accordingToMapping->describe(VerbosityLevel::typeOnly()),
+				$propertyWritableType->describe(VerbosityLevel::typeOnly())
+			);
+		}
+
+		return $errors;
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
@@ -153,6 +153,21 @@ class EntityColumnRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testEmbeddable(): void
+	{
+		$this->analyse([__DIR__ . '/data/Embeddable.php'], []);
+	}
+
+	public function testBrokenEmbeddable(): void
+	{
+		$this->analyse([__DIR__ . '/data/BrokenEmbeddable.php'], [
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\BrokenEmbeddable::$one type mapping mismatch: database can contain string|null but property expects string.',
+				16,
+			],
+		]);
+	}
+
 	public function testUnknownType(): void
 	{
 		$this->analyse([__DIR__ . '/data/EntityWithUnknownType.php'], [

--- a/tests/Rules/Doctrine/ORM/EntityEmbeddableRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityEmbeddableRuleTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+
+/**
+ * @extends RuleTestCase<EntityEmbeddableRule>
+ */
+class EntityEmbeddableRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new EntityEmbeddableRule(
+			new ObjectMetadataResolver(__DIR__ . '/entity-manager.php', null)
+		);
+	}
+
+	public function testEmbedded(): void
+	{
+		$this->analyse([__DIR__ . '/data/EntityWithEmbeddable.php'], []);
+	}
+
+	public function testEmbeddedWithWrongTypeHint(): void
+	{
+		$this->analyse([__DIR__ . '/data/EntityWithBrokenEmbeddable.php'], [
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\EntityWithBrokenEmbeddable::$embedded type mapping mismatch: mapping specifies PHPStan\Rules\Doctrine\ORM\Embeddable but property expects int.',
+				24,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/data/BrokenEmbeddable.php
+++ b/tests/Rules/Doctrine/ORM/data/BrokenEmbeddable.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable()
+ */
+class BrokenEmbeddable
+{
+	/**
+	 * @ORM\Column(type="string", nullable=true)
+	 * @var string
+	 */
+	private $one;
+}

--- a/tests/Rules/Doctrine/ORM/data/Embeddable.php
+++ b/tests/Rules/Doctrine/ORM/data/Embeddable.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable()
+ */
+class Embeddable
+{
+	/**
+	 * @ORM\Column(type="string")
+	 * @var string
+	 */
+	private $one;
+}

--- a/tests/Rules/Doctrine/ORM/data/EntityWithBrokenEmbeddable.php
+++ b/tests/Rules/Doctrine/ORM/data/EntityWithBrokenEmbeddable.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class EntityWithBrokenEmbeddable
+{
+
+	/**
+	 * @ORM\Id()
+	 * @ORM\Column(type="integer")
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @ORM\Embedded(class=Embeddable::class)
+	 * @var int
+	 */
+	private $embedded;
+}

--- a/tests/Rules/Doctrine/ORM/data/EntityWithEmbeddable.php
+++ b/tests/Rules/Doctrine/ORM/data/EntityWithEmbeddable.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class EntityWithEmbeddable
+{
+
+	/**
+	 * @ORM\Id()
+	 * @ORM\Column(type="integer")
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @ORM\Embedded(class=Embeddable::class)
+	 * @var Embeddable
+	 */
+	private $embedded;
+
+	/**
+	 * @ORM\Embedded(class=Embeddable::class)
+	 * @var ?Embeddable
+	 */
+	private $nullable;
+}


### PR DESCRIPTION
Today at work I've realized there's currently no rules for ORM's embeddables so here's an attempt to change that :) I'll remove WIP once I'm done with my goals, for now I'm making a PR for early feedback (or to learn that somebody else is already working on this).

Goals:
- [x] Check if property's type agrees with ORM's knowledge
- [x] Check columns specified in embeddables just like for entities