### PR TITLE
ObjectMetadataResolver ignore error on invalid entity for abstract class

### DIFF
--- a/tests/Type/Doctrine/ObjectMetadataResolverTest.php
+++ b/tests/Type/Doctrine/ObjectMetadataResolverTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use Doctrine\ORM\Mapping\MappingException;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectMetadataResolverTest extends TestCase
+{
+
+	/** @var ObjectMetadataResolver */
+	private $resolver;
+
+	protected function setUp(): void
+	{
+		$this->resolver = new ObjectMetadataResolver(__DIR__ . '/entity-manager.php', null);
+	}
+
+	public function testGetRepositoryClassThrowOnInvalidEntity(): void
+	{
+		$this->expectException(MappingException::class);
+		$this->expectExceptionMessage(
+			sprintf('Class "%s" is not a valid entity or mapped super class.', MyInvalidEntity::class)
+		);
+
+		$this->resolver->getRepositoryClass(MyInvalidEntity::class);
+	}
+
+	public function testGetRepositoryClassIgnoreErrorWithAbstractClass(): void
+	{
+		$repositoryClass = $this->resolver->getRepositoryClass(MyInvalidAbstractEntity::class);
+
+		self::assertEquals('Doctrine\ORM\EntityRepository', $repositoryClass);
+	}
+
+}

--- a/tests/Type/Doctrine/data/MyInvalidAbstractEntity.php
+++ b/tests/Type/Doctrine/data/MyInvalidAbstractEntity.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPStan\Type\Doctrine;
+
+abstract class MyInvalidAbstractEntity
+{
+
+}

--- a/tests/Type/Doctrine/data/MyInvalidEntity.php
+++ b/tests/Type/Doctrine/data/MyInvalidEntity.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPStan\Type\Doctrine;
+
+class MyInvalidEntity
+{
+
+}

--- a/tests/Type/Doctrine/entity-manager.php
+++ b/tests/Type/Doctrine/entity-manager.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+
+AnnotationRegistry::registerUniqueLoader('class_exists');
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__);
+$config->setProxyNamespace('PHPstan\Doctrine\OrmProxies');
+$config->setMetadataCacheImpl(new ArrayCache());
+
+$config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), []));
+
+return EntityManager::create(
+	[
+		'driver' => 'pdo_sqlite',
+		'memory' => true,
+	],
+	$config
+);


### PR DESCRIPTION
I go for the simplest solution: try-catching Doctrine mapping error if the class is abstract.

Fix issue #112