### PR TITLE
Add Stub for DBAL\QueryBuilder

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -22,6 +22,8 @@ parameters:
 		- stubs/ObjectManager.stub
 		- stubs/ObjectManagerDecorator.stub
 		- stubs/ObjectRepository.stub
+		- stubs/QueryBuilder.stub
+		- stubs/Statement.stub
 		- stubs/Persistence/ManagerRegistry.stub
 		- stubs/Persistence/ObjectManager.stub
 		- stubs/Persistence/ObjectManagerDecorator.stub

--- a/stubs/QueryBuilder.stub
+++ b/stubs/QueryBuilder.stub
@@ -1,0 +1,49 @@
+<?php
+
+namespace Doctrine\DBAL\Query;
+
+use Doctrine\DBAL\Statement;
+
+/**
+ * @template TExecute
+ */
+class QueryBuilder
+{
+	/**
+	 * @phpstan-param mixed $select
+	 * @phpstan-return QueryBuilder<Statement>
+	 */
+	public function select($select = null);
+
+	/**
+	 * @phpstan-param mixed $select
+	 * @phpstan-return QueryBuilder<Statement>
+	 */
+	public function addSelect($select = null);
+
+	/**
+	 * @phpstan-param string|null $delete
+	 * @phpstan-param string|null $alias
+	 * @phpstan-return QueryBuilder<int>
+	 */
+	public function delete($delete = null, $alias = null);
+
+	/**
+	 * @phpstan-param string|null $update
+	 * @phpstan-param string|null $alias
+	 * @phpstan-return QueryBuilder<int>
+	 */
+	public function update($update = null, $alias = null);
+
+
+	/**
+	 * @phpstan-param string|null $insert
+	 * @phpstan-return QueryBuilder<int>
+	 */
+	public function insert($insert = null);
+
+	/**
+	 * @phpstan-return TExecute
+	 */
+	public function execute();
+}

--- a/stubs/Statement.stub
+++ b/stubs/Statement.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+class Statement
+{
+
+}


### PR DESCRIPTION
This adds a stub for `Doctrine\DBAL\QueryBuilder`.
The `QueryBuilder` has two possible states:

1. By default, or as the return type of `select()` or `addSelect()` the `execute()` method returns an instance of `Doctrine\DBAL\Statement`.
2. The instance returned from calling `insert()`, `update()` or `delete()` will return `int` on calling `execute()`.

I did not manage to set the default (without calling `select()` or `addSelect()`) to return a `Statement`. I don't know if this is possible with stubs. If this is only possible by writing a full type definition, I can look into it. On the other hand, calling `execute` without calling one of the other methods first seems like a very rare usecase, so maybe this isn't even necessary.
