### PR TITLE
Add ClassMetadataInfo::getAssociationTargetClass stub

### DIFF
--- a/stubs/ClassMetadataInfo.stub
+++ b/stubs/ClassMetadataInfo.stub
@@ -8,4 +8,10 @@ class ClassMetadataInfo
 	/** @var string|null */
 	public $customRepositoryClassName;
 
+    /**
+     * @param string $assocName
+     * @return class-string
+     */
+    public function getAssociationTargetClass($assocName);
+
 }


### PR DESCRIPTION
This will fix false positives when using the returned string from `ClassMetadaInfo::getAssociationTargetClass` as `class-string` param

Example code:
```php
final class SelectInLoader
{
    /** @var EntityManagerInterface */
    private $em;

    public function __construct(EntityManagerInterface $em)
    {
        $this->em = $em;
    }

    /**
     * @return Address[]
     */
    public function overlyComplicatedWayToGetCustomerAddresses(Customer $customer): array
    {
        $addressClass = $this->em
            ->getClassMetadata(Customer::class)
            ->getAssociationTargetClass('address');

        return $this->em->getRepository($addressClass)->findBy(['customer' => $customer]);
    }
}
```

Current (false positive) phpstan errors:
```
 ------ ------------------------------------------------------------- 
  Line   SelectInLoader.php                                           
 ------ ------------------------------------------------------------- 
  30     Parameter #1 $className of method                            
         Doctrine\Persistence\ObjectManager::getRepository() expects  
         class-string<mixed>, string given.                           
  30     Unable to resolve the template type T in call to method      
         Doctrine\Persistence\ObjectManager::getRepository()          
 ------ ------------------------------------------------------------- 
```