### PR TITLE
Handle multiple Doctrine managers

### DIFF
--- a/src/Reflection/Doctrine/EntityRepositoryClassReflectionExtension.php
+++ b/src/Reflection/Doctrine/EntityRepositoryClassReflectionExtension.php
@@ -60,7 +60,7 @@ class EntityRepositoryClassReflectionExtension implements \PHPStan\Reflection\Me
 			return false;
 		}
 
-		$objectManager = $this->objectMetadataResolver->getObjectManager();
+		$objectManager = $this->objectMetadataResolver->getObjectManagerForClass($entityClassType->getClassName());
 		if ($objectManager === null) {
 			return false;
 		}

--- a/src/Rules/Doctrine/ORM/EntityColumnRule.php
+++ b/src/Rules/Doctrine/ORM/EntityColumnRule.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Doctrine\ORM;
 
+use Doctrine\Persistence\AbstractManagerRegistry;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MissingPropertyFromReflectionException;
@@ -58,12 +59,13 @@ class EntityColumnRule implements Rule
 			return [];
 		}
 
-		$objectManager = $this->objectMetadataResolver->getObjectManager();
+		$className = $class->getName();
+
+		$objectManager = $this->objectMetadataResolver->getObjectManagerForClass($className);
 		if ($objectManager === null) {
 			return [];
 		}
 
-		$className = $class->getName();
 		if ($objectManager->getMetadataFactory()->isTransient($className)) {
 			return [];
 		}

--- a/src/Rules/Doctrine/ORM/EntityRelationRule.php
+++ b/src/Rules/Doctrine/ORM/EntityRelationRule.php
@@ -42,12 +42,13 @@ class EntityRelationRule implements Rule
 			return [];
 		}
 
-		$objectManager = $this->objectMetadataResolver->getObjectManager();
+		$className = $class->getName();
+
+		$objectManager = $this->objectMetadataResolver->getObjectManagerForClass($className);
 		if ($objectManager === null) {
 			return [];
 		}
 
-		$className = $class->getName();
 		if ($objectManager->getMetadataFactory()->isTransient($className)) {
 			return [];
 		}

--- a/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
@@ -74,7 +74,7 @@ class RepositoryMethodCallRule implements Rule
 			return [];
 		}
 
-		$objectManager = $this->objectMetadataResolver->getObjectManager();
+		$objectManager = $this->objectMetadataResolver->getObjectManagerForClass($entityClass);
 		if ($objectManager === null) {
 			return [];
 		}


### PR DESCRIPTION
This is a merge request trying to solve #53 
This is a work in progress, your contributions are welcome!

I've pushed a first proof of concept for now, there's still a lot to do:

- [ ] Completely remove `ObjectMetadataResolver::getObjectManager()` in favor of `ObjectMetadataResolver::getObjectManagerForClass()`. Remaining usages:
  - [ ] `DqlRule::processNode` line 57
  - [ ] `QueryBuilderDqlRule::processNode` line 80
  - [ ] `QueryBuilderGetQueryDynamicReturnTypeExtension::getTypeFromMethodCall` line 71
  - [ ] `ExpressionBuilderDynamicReturnTypeExtension::getTypeFromMethodCall` line 71
- [ ] There is not tests for setting an `AbstractManagerRegistry` instead of an `ObjectManager` for `parameters.doctrine.objectManagerLoader`
- [ ] We might want to use another parameter as to not introduce confusion

With these changes, PHPStan is capable of analyzing simple code that uses multiple managers