### PR TITLE
Fix empty DQL with QueryBuilder::setParameters()

### DIFF
--- a/src/Type/Doctrine/QueryBuilder/QueryBuilderMethodDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/QueryBuilderMethodDynamicReturnTypeExtension.php
@@ -79,7 +79,7 @@ class QueryBuilderMethodDynamicReturnTypeExtension implements \PHPStan\Type\Dyna
 		if ($returnType instanceof MixedType) {
 			return false;
 		}
-		return $returnType->isSuperTypeOf(new ObjectType($this->getClass()))->yes();
+		return (new ObjectType($this->getClass()))->isSuperTypeOf($returnType)->yes();
 	}
 
 	public function getTypeFromMethodCall(

--- a/src/Type/Doctrine/QueryBuilder/QueryBuilderTypeSpecifyingExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/QueryBuilderTypeSpecifyingExtension.php
@@ -65,7 +65,7 @@ class QueryBuilderTypeSpecifyingExtension implements MethodTypeSpecifyingExtensi
 		if ($returnType instanceof MixedType) {
 			return new SpecifiedTypes([]);
 		}
-		if (!$returnType->isSuperTypeOf(new ObjectType($this->getClass()))->yes()) {
+		if (!(new ObjectType($this->getClass()))->isSuperTypeOf($returnType)->yes()) {
 			return new SpecifiedTypes([]);
 		}
 

--- a/tests/DoctrineIntegration/ORM/data/queryBuilder.php
+++ b/tests/DoctrineIntegration/ORM/data/queryBuilder.php
@@ -54,4 +54,18 @@ class Foo
 		return $queryBuilder->getQuery();
 	}
 
+	public function usingMethodThatReturnStatic(): ?MyEntity
+	{
+		$queryBuilder = $this->entityManager->createQueryBuilder();
+
+		$queryBuilder
+			->select('e')
+			->from(MyEntity::class, 'e')
+			->where('e.id = :id')
+			->setParameters([
+				'id' => 123,
+			]);
+
+		return $queryBuilder->getQuery()->getOneOrNullResult();
+	}
 }


### PR DESCRIPTION
Since version 0.12.18 I have a weird error:

```
QueryBuilder: [Syntax Error] line 0, col -1: Error: Expected IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration | PartialObjectExpression | "(" Subselect ")" | CaseExpression, got end of string.
DQL: SELECT
```

It is reported in code that uses the `QueryBuilder::setParameters()` method. I first replaced those calls with several `QueryBuilder::setParameter()` calls and the errors were not reported anymore, but it was an unsatisfactory solution.

I noticed that in that version, a new stub was added for the `QueryBuilder::setParameters()` method so I tried editing it. When replacing `@return static` with `@return self`, the errors were not reported anymore. I have no idea why this fixes the issue though so please let me know if there's a better way.