### PR TITLE
Check that doctrine entities are not final

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -33,3 +33,9 @@ services:
 			reportUnknownTypes: %doctrine.reportUnknownTypes%
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PHPStan\Rules\Doctrine\ORM\EntityNotFinalRule
+
+conditionalTags:
+	PHPStan\Rules\Doctrine\ORM\EntityNotFinalRule:
+		phpstan.rules.rule: %featureToggles.bleedingEdge%

--- a/src/Rules/Doctrine/ORM/EntityNotFinalRule.php
+++ b/src/Rules/Doctrine/ORM/EntityNotFinalRule.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Stmt\Class_>
+ */
+class EntityNotFinalRule implements Rule
+{
+
+	/** @var \PHPStan\Type\Doctrine\ObjectMetadataResolver */
+	private $objectMetadataResolver;
+
+	public function __construct(ObjectMetadataResolver $objectMetadataResolver)
+	{
+		$this->objectMetadataResolver = $objectMetadataResolver;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\Class_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (! $node->isFinal()) {
+			return [];
+		}
+
+		$objectManager = $this->objectMetadataResolver->getObjectManager();
+		if ($objectManager === null) {
+			return [];
+		}
+
+		$className = (string) $node->namespacedName;
+		try {
+			if ($objectManager->getMetadataFactory()->isTransient($className)) {
+				return [];
+			}
+		} catch (\ReflectionException $e) {
+			return [];
+		}
+
+		return [sprintf(
+			'Entity class %s is final which can cause problems with proxies.',
+			$className
+		)];
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/EntityNotFinalRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityNotFinalRuleTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+
+/**
+ * @extends RuleTestCase<EntityNotFinalRule>
+ */
+class EntityNotFinalRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new EntityNotFinalRule(
+			new ObjectMetadataResolver($this->createReflectionProvider(), __DIR__ . '/entity-manager.php', null)
+		);
+	}
+
+	/**
+	 * @dataProvider ruleProvider
+	 * @param string $file
+	 * @param mixed[] $expectedErrors
+	 */
+	public function testRule(string $file, array $expectedErrors): void
+	{
+		$this->analyse([$file], $expectedErrors);
+	}
+
+	/**
+	 * @return \Iterator<mixed[]>
+	 */
+	public function ruleProvider(): Iterator
+	{
+		yield 'final entity' => [
+			__DIR__ . '/data/FinalEntity.php',
+			[
+				[
+					'Entity class PHPStan\Rules\Doctrine\ORM\FinalEntity is final which can cause problems with proxies.',
+					10,
+				],
+			],
+		];
+
+		yield 'final non-entity' => [
+			__DIR__ . '/data/FinalNonEntity.php',
+			[],
+		];
+
+		yield 'correct entity' => [
+			__DIR__ . '/data/MyEntity.php',
+			[],
+		];
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/data/FinalEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/FinalEntity.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+final class FinalEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+}

--- a/tests/Rules/Doctrine/ORM/data/FinalNonEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/FinalNonEntity.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+final class FinalNonEntity
+{
+}


### PR DESCRIPTION
I create all my classes as final by default. This however can cause issues with Doctrine:

```
  [Doctrine\Common\Proxy\Exception\InvalidArgumentException]
  Unable to create a proxy for a final class "<entity class>".
```

What do you think about a rule to avoid final entities?