### PR TITLE
Guard against crashes when only an entity's interface is known

### DIFF
--- a/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
@@ -59,7 +59,7 @@ class RepositoryMethodCallRule implements Rule
 			return [];
 		}
 		$entityClass = $entityClassType->getClassName();
-		
+
 		if (interface_exists($entityClass)) {
 			return [];
 		}

--- a/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
@@ -59,6 +59,10 @@ class RepositoryMethodCallRule implements Rule
 			return [];
 		}
 		$entityClass = $entityClassType->getClassName();
+		
+		if (interface_exists($entityClass)) {
+			return [];
+		}
 
 		$methodNameIdentifier = $node->name;
 		if (!$methodNameIdentifier instanceof Node\Identifier) {

--- a/tests/Rules/Doctrine/ORM/EntityImplementingInterfaceTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityImplementingInterfaceTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+
+/**
+ * @extends RuleTestCase<RepositoryMethodCallRule>
+ */
+class EntityImplementingInterfaceTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new RepositoryMethodCallRule(new ObjectMetadataResolver($this->createReflectionProvider(), __DIR__ . '/entity-manager.php', null));
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/magic-repository.neon'];
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/repository-findBy-interface.php'], [
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntityImplementingInterface>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntityImplementingInterface does not have a field named $nonexistent.',
+				22,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class MyEntity implements MyExtendedInterface
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	public function requiredMethod()
+	{
+		return true;
+	}
+}

--- a/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class MyEntityImplementingInterface implements MyExtendedInterface
+class MyEntityImplementingInterface implements MyInterface
 {
 	/**
 	 * @ORM\Id()
@@ -18,13 +18,14 @@ class MyEntityImplementingInterface implements MyExtendedInterface
 	 */
 	private $id;
 
-	public function requiredMethod(): bool
-	{
-		return true;
-	}
+	/**
+	 * @ORM\Column()
+	 * @var string
+	 */
+	private $name;
 
 	public function getName(): string
 	{
-		return 'my name';
+		return $this->name;
 	}
 }

--- a/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class MyEntity implements MyExtendedInterface
+class MyEntityImplementingInterface implements MyExtendedInterface
 {
 	/**
 	 * @ORM\Id()
@@ -18,7 +18,7 @@ class MyEntity implements MyExtendedInterface
 	 */
 	private $id;
 
-	public function requiredMethod()
+	public function requiredMethod(): bool
 	{
 		return true;
 	}

--- a/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyEntityImplementingInterface.php
@@ -22,4 +22,9 @@ class MyEntityImplementingInterface implements MyExtendedInterface
 	{
 		return true;
 	}
+
+	public function getName(): string
+	{
+		return 'my name';
+	}
 }

--- a/tests/Rules/Doctrine/ORM/data/MyExtendedInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyExtendedInterface.php
@@ -1,8 +1,0 @@
-<?php declare(strict_types = 1);
-
-namespace PHPStan\Rules\Doctrine\ORM;
-
-interface MyExtendedInterface extends MyInterface
-{
-    public function getName(): string;
-}

--- a/tests/Rules/Doctrine/ORM/data/MyExtendedInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyExtendedInterface.php
@@ -4,5 +4,5 @@ namespace PHPStan\Rules\Doctrine\ORM;
 
 interface MyExtendedInterface extends MyInterface
 {
-    // No new methods
+    public function getName(): string;
 }

--- a/tests/Rules/Doctrine/ORM/data/MyExtendedInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyExtendedInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+interface MyExtendedInterface extends MyInterface
+{
+    // No new methods
+}

--- a/tests/Rules/Doctrine/ORM/data/MyInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyInterface.php
@@ -4,5 +4,5 @@ namespace PHPStan\Rules\Doctrine\ORM;
 
 interface MyInterface
 {
-	public function requiredMethod(): bool;
+	public function getName(): string;
 }

--- a/tests/Rules/Doctrine/ORM/data/MyInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyInterface.php
@@ -4,8 +4,5 @@ namespace PHPStan\Rules\Doctrine\ORM;
 
 interface MyInterface
 {
-	/**
-	 * @return bool
-	 */
-	public function requiredMethod();
+	public function requiredMethod(): bool;
 }

--- a/tests/Rules/Doctrine/ORM/data/MyInterface.php
+++ b/tests/Rules/Doctrine/ORM/data/MyInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+interface MyInterface
+{
+	/**
+	 * @return bool
+	 */
+	public function requiredMethod();
+}

--- a/tests/Rules/Doctrine/ORM/data/repository-findBy-interface.php
+++ b/tests/Rules/Doctrine/ORM/data/repository-findBy-interface.php
@@ -4,7 +4,7 @@ namespace PHPStan\Rules\Doctrine\ORM;
 
 use Doctrine\ORM\EntityManager;
 
-class RepositoryFindByCalls
+class RepositoryForInterfaceFindByCalls
 {
 
 	/** @var EntityManager */
@@ -15,10 +15,21 @@ class RepositoryFindByCalls
 		$this->entityManager = $entityManager;
 	}
 
-	public function doFindBy(): void
+	public function doFindByWithConcreteClass(): void
 	{
 		$entityRepository = $this->entityManager->getRepository(MyEntityImplementingInterface::class);
 		$entityRepository->findBy(['id' => 1]);
+		$entityRepository->findBy(['nonexistent' => 'test']);
+	}
+
+	public function doFindByWithInterface(MyInterface $entity): void
+	{
+		$entityRepository = $this->entityManager->getRepository(get_class($entity));
+		// This is likely to work, but cannot be inferred from the interface
+		// alone
+		$repo->findBy(['name' => $entity->getName()]);
+		// This is NOT likely to work, but can't be proven without examining
+		// all implementations of the interface
 		$entityRepository->findBy(['nonexistent' => 'test']);
 	}
 

--- a/tests/Rules/Doctrine/ORM/data/repository-findBy-interface.php
+++ b/tests/Rules/Doctrine/ORM/data/repository-findBy-interface.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\EntityManager;
+
+class RepositoryFindByCalls
+{
+
+	/** @var EntityManager */
+	private $entityManager;
+
+	public function __construct(EntityManager $entityManager)
+	{
+		$this->entityManager = $entityManager;
+	}
+
+	public function doFindBy(): void
+	{
+		$entityRepository = $this->entityManager->getRepository(MyEntityImplementingInterface::class);
+		$entityRepository->findBy(['id' => 1]);
+		$entityRepository->findBy(['nonexistent' => 'test']);
+	}
+
+}


### PR DESCRIPTION
I got a "please report this stack trace" error immediately following the extended configuration of this extension.

After a bit of digging while writing up the issue, including recovering a truncated stack trace, I found that this extension was trying to call `$objectManager->getClassMetadata()` with one of the interfaces that one of my entities implements, and Doctrine doesn't much care for you doing that. This change checks whether the class referenced is actually an interface and filters out further analysis since it a) crashes and b) isn't relevant for determining which fields are present on a Doctrine entity.

```
# phpstan.neon
includes:
    - phpstan-baseline.neon
    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
    - vendor/phpstan/phpstan-doctrine/extension.neon
    - vendor/phpstan/phpstan-doctrine/rules.neon
    - vendor/phpstan/phpstan-phpunit/extension.neon
parameters:
    doctrine:
        objectManagerLoader: tests/phpstanObjectManagerLoader.php
```

```php
# tests/phpstanObjectManagerLoader.php
<?php

use Doctrine\ORM\EntityManagerInterface;

require 'vendor/autoload.php';

$config = require 'config.php';
return $config->get(EntityManagerInterface::class);
```

This is a summary of the class hierarchy that triggered the error, though of course each interface and class is in its own autoloadable file:

```php
namespace X\Y\G {
  interface NodeInterface { ... }
}
namespace X\Y\Z {
  interface ProductInterface extends \X\Y\G\NodeInterface
  {
    /* no new methods */ 
  }
  /**
   * @Entity
   * @Table(name="products")
   */
  class Product implements ProductInterface
  {
    // typical class definition, with doctrine php annotations
  }
}
```

While by the look of the stack trace it's some sort of Doctrine-generated issue, it seems like the debug output is being truncated.