### PR TITLE
Add documentation on bootstrap file with Symfony 5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ $kernel->boot();
 return $kernel->getContainer()->get('doctrine')->getManager();
 ```
 
+In Symfony 5, the bootsrap file might be located in `tests/` folder on even missing. Check the [Symfony documentation about custom bootstrap process](https://symfony.com/doc/current/testing/bootstrap.html) for more informations.
+
 ## Custom types
 
 If your application uses custom Doctrine types, you can write your own type descriptors to analyse them properly.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $kernel->boot();
 return $kernel->getContainer()->get('doctrine')->getManager();
 ```
 
-In Symfony 5, the bootsrap file might be located in `tests/` folder on even missing. Check the [Symfony documentation about custom bootstrap process](https://symfony.com/doc/current/testing/bootstrap.html) for more informations.
+In Symfony 5, the bootstrap file might be located in `tests/` folder or even missing. Check the [Symfony documentation about custom bootstrap process](https://symfony.com/doc/current/testing/bootstrap.html) for more informations.
 
 ## Custom types
 


### PR DESCRIPTION
In Symfony 5, the recipe does not create a `config/bootstrap.php` file. 
It should be located in `tests` folder if you have some tests, or missing if not, so I added a link to document how to deal with that file.