### PR TITLE
Narrow type of Collection::first() when using Collection::isEmpty()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require-dev": {
 		"doctrine/annotations": "^1.11.0",
-		"doctrine/collections": "^1.0",
+		"doctrine/collections": "^1.6",
 		"doctrine/common": "^2.7 || ^3.0",
 		"doctrine/dbal": "^2.11.0",
 		"doctrine/mongodb-odm": "^1.3 || ^2.1",

--- a/extension.neon
+++ b/extension.neon
@@ -310,3 +310,9 @@ services:
 		tags: [phpstan.doctrine.typeDescriptor]
 		arguments:
 			uuidTypeName: Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType
+
+	# Doctrine Collection
+	-
+		class: PHPStan\Type\Doctrine\Collection\FirstTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/src/Type/Doctrine/Collection/FirstTypeSpecifyingExtension.php
+++ b/src/Type/Doctrine/Collection/FirstTypeSpecifyingExtension.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine\Collection;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+
+final class FirstTypeSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	private const COLLECTION_CLASS = 'Doctrine\Common\Collections\Collection';
+	private const IS_EMPTY_METHOD_NAME = 'isEmpty';
+	private const FIRST_METHOD_NAME = 'first';
+
+	/** @var TypeSpecifier */
+	private $typeSpecifier;
+
+	public function getClass(): string
+	{
+		return self::COLLECTION_CLASS;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		TypeSpecifierContext $context
+	): bool
+	{
+		return (
+			$methodReflection->getDeclaringClass()->getName() === self::COLLECTION_CLASS
+			|| $methodReflection->getDeclaringClass()->isSubclassOf(self::COLLECTION_CLASS)
+		)
+		&& $methodReflection->getName() === self::IS_EMPTY_METHOD_NAME;
+	}
+
+	public function specifyTypes(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context
+	): SpecifiedTypes
+	{
+		return $this->typeSpecifier->create(
+			new MethodCall($node->var, self::FIRST_METHOD_NAME),
+			new ConstantBooleanType(false),
+			$context
+		);
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+}

--- a/tests/Type/Doctrine/Collection/FirstTypeSpecifyingExtensionTest.php
+++ b/tests/Type/Doctrine/Collection/FirstTypeSpecifyingExtensionTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine\Collection;
+
+use PHPStan\Rules\Rule;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<VariableTypeReportingRule>
+ */
+class FirstTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new VariableTypeReportingRule();
+	}
+
+	/**
+	 * @return \PHPStan\Type\MethodTypeSpecifyingExtension[]
+	 */
+	protected function getMethodTypeSpecifyingExtensions(): array
+	{
+		return [
+			new FirstTypeSpecifyingExtension(),
+		];
+	}
+
+	public function testExtension(): void
+	{
+		$this->analyse([__DIR__ . '/data/collection.php'], [
+			[
+				'Variable $entityOrFalse is: MyEntity|false',
+				18,
+			],
+			[
+				'Variable $false is: false',
+				22,
+			],
+			[
+				'Variable $entity is: MyEntity',
+				27,
+			],
+		]);
+	}
+
+}

--- a/tests/Type/Doctrine/Collection/VariableTypeReportingRule.php
+++ b/tests/Type/Doctrine/Collection/VariableTypeReportingRule.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine\Collection;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+
+/**
+ * @implements \PHPStan\Rules\Rule<Node\Expr\Variable>
+ */
+class VariableTypeReportingRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\Variable::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!is_string($node->name)) {
+			return [];
+		}
+		if (!$scope->isInFirstLevelStatement()) {
+			return [];
+		};
+
+		if ($scope->isInExpressionAssign($node)) {
+			return [];
+		}
+
+		return [
+			sprintf(
+				'Variable $%s is: %s',
+				$node->name,
+				$scope->getType($node)->describe(\PHPStan\Type\VerbosityLevel::value())
+			),
+		];
+	}
+
+}

--- a/tests/Type/Doctrine/Collection/data/collection.php
+++ b/tests/Type/Doctrine/Collection/data/collection.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class MyEntity
+{
+
+}
+
+$new = new MyEntity();
+
+/**
+ * @var ArrayCollection<int, MyEntity> $collection
+ */
+$collection = new ArrayCollection();
+
+$entityOrFalse = $collection->first();
+$entityOrFalse;
+
+if ($collection->isEmpty()) {
+	$false = $collection->first();
+	$false;
+}
+
+if (!$collection->isEmpty()) {
+	$entity = $collection->first();
+	$entity;
+}


### PR DESCRIPTION
I really wanted support for `Collection::isEmpty()` together with `Collection::first()` as proposed in https://github.com/phpstan/phpstan-doctrine/pull/153.

This adds tests and they pass.

However, I'm not too sure if the logic in the extension is correct. 

When I change the code to:
```php
$classReflection = $methodReflection->getDeclaringClass();
		$methodVariants = $classReflection->getNativeMethod(self::FIRST_METHOD_NAME)->getVariants();

		if ($context->truthy()) {
			return $this->typeSpecifier->create(
				new MethodCall($node->var, self::FIRST_METHOD_NAME),
				new ConstantBooleanType(false),
				$context
			);
		}

		return $this->typeSpecifier->create(
			new MethodCall($node->var, self::FIRST_METHOD_NAME),
			TypeCombinator::remove(ParametersAcceptorSelector::selectSingle($methodVariants)->getReturnType(), new ConstantBooleanType(false)),
			$context
		);
```

The test fails for this scenario:
```
if (!$collection->isEmpty()) {
	$entity = $collection->first();
	$entity; // 27: Variable $entity is: MyEntity|false
}
```