### PR TITLE
Use @template-covariant instead of @template in EntityRepository

### DIFF
--- a/stubs/Collections/Collection.stub
+++ b/stubs/Collections/Collection.stub
@@ -8,7 +8,7 @@ use IteratorAggregate;
 
 /**
  * @template TKey
- * @template T
+ * @template-covariant T
  * @extends IteratorAggregate<TKey, T>
  * @extends ArrayAccess<TKey|null, T>
  */

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
- * @template-covariance TEntityClass
+ * @template-covariant TEntityClass
  * @implements ObjectRepository<TEntityClass>
  */
 class EntityRepository implements ObjectRepository

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
- * @template TEntityClass
+ * @template-covariance TEntityClass
  * @implements ObjectRepository<TEntityClass>
  */
 class EntityRepository implements ObjectRepository

--- a/stubs/Persistence/ObjectRepository.stub
+++ b/stubs/Persistence/ObjectRepository.stub
@@ -3,7 +3,7 @@
 namespace Doctrine\Persistence;
 
 /**
- * @template TEntityClass
+ * @template-covariant TEntityClass
  */
 interface ObjectRepository
 {


### PR DESCRIPTION
Using `@template-covariant` instead of `@template` on `EntityRepository` allows for more flexible use cases. Example: https://github.com/phpstan/phpstan/issues/4582