### PR TITLE
Add testcase for entities that are annotated final

### DIFF
--- a/src/Rules/Doctrine/ORM/EntityNotFinalRule.php
+++ b/src/Rules/Doctrine/ORM/EntityNotFinalRule.php
@@ -34,7 +34,7 @@ class EntityNotFinalRule implements Rule
 		if ($classReflection === null) {
 			throw new \PHPStan\ShouldNotHappenException();
 		}
-		if (!$classReflection->isFinal()) {
+		if (!$classReflection->isFinalByKeyword()) {
 			return [];
 		}
 

--- a/tests/Rules/Doctrine/ORM/EntityNotFinalRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityNotFinalRuleTest.php
@@ -45,6 +45,11 @@ class EntityNotFinalRuleTest extends RuleTestCase
 			],
 		];
 
+		yield 'final annotated entity' => [
+			__DIR__ . '/data/FinalAnnotatedEntity.php',
+			[],
+		];
+
 		yield 'final non-entity' => [
 			__DIR__ . '/data/FinalNonEntity.php',
 			[],

--- a/tests/Rules/Doctrine/ORM/data/FinalAnnotatedEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/FinalAnnotatedEntity.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @final
+ * @ORM\Entity()
+ */
+class FinalAnnotatedEntity
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+}


### PR DESCRIPTION
I just update the plugin from `0.12.33` to `0.12.34` and after this i got several messages about making my entities not final because of how doctrine works, which is right. But my entities are not final on language level. I would expect that this message is not displayed if i annotate the entity to be final. So i added a testcase based on my expected behavior. If it is working right now as expected i would change the test accordingly :)

Why does this happen now? I dont know, i looked into the diff between the two releases and did not find which changes caused this. This feature is bleeding edge since `0.12.20` it should have happened before i guess.

PS: i did not run the testcase locally wanted the workflow to do the work 😆 