### PR TITLE
(fix): copy and merge are deprecated

### DIFF
--- a/stubs/EntityManager.stub
+++ b/stubs/EntityManager.stub
@@ -19,6 +19,7 @@ class EntityManager implements EntityManagerInterface
 	 * @template T
 	 * @phpstan-param T $entity
 	 * @phpstan-return T
+	 * @deprecated 2.7 This method is being removed from the ORM and won't have any replacement
 	 */
 	public function merge($entity);
 
@@ -51,6 +52,7 @@ class EntityManager implements EntityManagerInterface
 	 * @phpstan-param T $entity
 	 * @phpstan-param bool $deep
 	 * @phpstan-return T
+	 * @deprecated 2.7 This method is being removed from the ORM and won't have any replacement
 	 */
 	public function copy($entity, $deep = false);
 

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -52,6 +52,7 @@ interface EntityManagerInterface extends ObjectManager
 	 * @phpstan-param T $entity
 	 * @phpstan-param bool $deep
 	 * @phpstan-return T
+	 * @deprecated 2.7 This method is being removed from the ORM and won't have any replacement
 	 */
 	public function copy($entity, $deep = false);
 


### PR DESCRIPTION
Updating stubs to add new deprecations.

This is a fix related to this issue: https://github.com/phpstan/phpstan-deprecation-rules/issues/40, because of the stubs the errors were not being shown.
