### PR TITLE
Carbon Type Descriptors via ReflectionDescriptor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"doctrine/mongodb-odm": "^1.3 || ^2.1",
 		"doctrine/orm": "^2.9.1",
 		"doctrine/persistence": "^1.1 || ^2.0",
+		"nesbot/carbon": "^2.49",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpstan/phpstan-phpunit": "^0.12.16",
 		"phpstan/phpstan-strict-rules": "^0.12.5",

--- a/extension.neon
+++ b/extension.neon
@@ -296,6 +296,12 @@ services:
 
 	# 3rd party Type descriptors
 	-
+		factory: PHPStan\Type\Doctrine\Descriptors\ReflectionDescriptor('Carbon\Doctrine\CarbonImmutableType')
+		tags: [phpstan.doctrine.typeDescriptor]
+	-
+		factory: PHPStan\Type\Doctrine\Descriptors\ReflectionDescriptor('Carbon\Doctrine\CarbonType')
+		tags: [phpstan.doctrine.typeDescriptor]
+	-
 		class: PHPStan\Type\Doctrine\Descriptors\Ramsey\UuidTypeDescriptor
 		tags: [phpstan.doctrine.typeDescriptor]
 		arguments:

--- a/tests/Rules/Doctrine/ORM/data/MyBrokenEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/MyBrokenEntity.php
@@ -125,4 +125,27 @@ class MyBrokenEntity extends MyBrokenSuperclass
 	 */
 	private $numericString;
 
+	/**
+	 * @ORM\Column(type="carbon")
+	 * @var \Carbon\CarbonImmutable
+	 */
+	private $invalidCarbon;
+
+	/**
+	 * @ORM\Column(type="carbon_immutable")
+	 * @var \Carbon\Carbon
+	 */
+	private $invalidCarbonImmutable;
+
+	/**
+	 * @ORM\Column(type="carbon")
+	 * @var \Carbon\Carbon
+	 */
+	private $validCarbon;
+
+	/**
+	 * @ORM\Column(type="carbon_immutable")
+	 * @var \Carbon\CarbonImmutable
+	 */
+	private $validCarbonImmutable;
 }


### PR DESCRIPTION
## Description
This PR adds type descriptors for [Carbon](https://carbon.nesbot.com/) date types Carbon and CarbonImmutable using the ReflectionDescriptor.

Made possible after: https://github.com/briannesbitt/Carbon/pull/2344.

## Features / Changes
- [x] Registers descriptors in `extension.neon`
- [x] Adds test cases in `MyBrokenEntity.php`
