### PR TITLE
Discover repository class from `#[Entity]` attribute on PHP 8

### DIFF
--- a/attribute-errors.neon
+++ b/attribute-errors.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method ReflectionClass::getAttributes\\(\\)\\.$#"
+			count: 1
+			path: src/Type/Doctrine/ObjectMetadataResolver.php

--- a/ignore-by-php-version.neon.php
+++ b/ignore-by-php-version.neon.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+use PHPStan\DependencyInjection\NeonAdapter;
+
+$adapter = new NeonAdapter();
+
+$config = [];
+
+if (PHP_VERSION_ID < 80000) {
+	$config = array_merge_recursive($config, $adapter->load(__DIR__ . '/attribute-errors.neon'));
+}
+
+$config['parameters']['phpVersion'] = PHP_VERSION_ID;
+
+return $config;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
 	- extension.neon
 	- rules.neon
+	- ignore-by-php-version.neon.php
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-phpunit/rules.neon


### PR DESCRIPTION
By doing it like this, we don't need to instantiate the object manager at all which makes PHPStan run faster and more reliable. Very often I had to manually clear my Symfony cache and re-run PHPStan.

Unfortunately, BetterReflection doesn't support attributes yet so therefore we need to use native `ReflectionClass`.

See https://github.com/phpstan/phpstan/discussions/5863#discussioncomment-1823297