### PR TITLE
Use `literal-string` type for `QueryBuilder::where()`

### DIFF
--- a/stubs/ORM/QueryBuilder.stub
+++ b/stubs/ORM/QueryBuilder.stub
@@ -14,4 +14,13 @@ class QueryBuilder
 
 	}
 
+	/**
+	 * @param literal-string|object|array $predicates
+	 * @return $this
+	 */
+	public function where($predicates)
+	{
+
+	}
+
 }

--- a/stubs/ORM/QueryBuilder.stub
+++ b/stubs/ORM/QueryBuilder.stub
@@ -15,7 +15,7 @@ class QueryBuilder
 	}
 
 	/**
-	 * @param literal-string|object|array $predicates
+	 * @param literal-string|object|array<mixed> $predicates
 	 * @return $this
 	 */
 	public function where($predicates)


### PR DESCRIPTION
Hi Ondřej, this is following up on an email on the 26th August, where you suggested updating the PHPStan stub files here.

I have tried to get [Doctrine ORM updated](https://github.com/doctrine/orm/pull/9188), but no luck so far (see also [Issue 8933](https://github.com/doctrine/orm/issues/8933)).

I've been running some tests, and cannot find any problems so far, but I'd still like to be cautious and limit it to a single method. I'll keep an eye out for any feedback, and try to help resolve any issues.