### PR TITLE
Register DBAL types automatically so that `EntityColumnRule` works without defining a `objectManagerLoader`

### DIFF
--- a/src/Rules/Doctrine/ORM/EntityColumnRule.php
+++ b/src/Rules/Doctrine/ORM/EntityColumnRule.php
@@ -72,7 +72,7 @@ class EntityColumnRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$this->bleedingEdge && !$this->objectMetadataResolver->hasObjectManagerLoader()) {
+		if (!$this->bleedingEdge) {
 			return [];
 		}
 		$class = $scope->getClassReflection();

--- a/src/Type/Doctrine/Descriptors/Ramsey/UuidTypeDescriptor.php
+++ b/src/Type/Doctrine/Descriptors/Ramsey/UuidTypeDescriptor.php
@@ -12,6 +12,7 @@ use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\Doctrine\UuidBinaryType;
 use Ramsey\Uuid\Doctrine\UuidType;
 use Ramsey\Uuid\UuidInterface;
+use ReflectionClass;
 use function in_array;
 use function sprintf;
 
@@ -39,6 +40,18 @@ class UuidTypeDescriptor implements DoctrineTypeDescriptor
 				'Unexpected UUID column type "%s" provided',
 				$uuidTypeName
 			));
+		}
+
+		$reflector = new ReflectionClass($uuidTypeName);
+		$methodReflector = $reflector->getMethod('getName');
+		if ($methodReflector->isStatic()) {
+			$name = $uuidTypeName::getName();
+		} else {
+			$name = (new $uuidTypeName)->getName();
+		}
+
+		if (!\Doctrine\DBAL\Types\Type::hasType($name)) {
+			\Doctrine\DBAL\Types\Type::addType($name, $uuidTypeName);
 		}
 
 		$this->uuidTypeName = $uuidTypeName;

--- a/src/Type/Doctrine/Descriptors/ReflectionDescriptor.php
+++ b/src/Type/Doctrine/Descriptors/ReflectionDescriptor.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use ReflectionClass;
 
 class ReflectionDescriptor implements DoctrineTypeDescriptor
 {
@@ -22,6 +23,18 @@ class ReflectionDescriptor implements DoctrineTypeDescriptor
 	 */
 	public function __construct(string $type, Broker $broker)
 	{
+		$reflector = new ReflectionClass($type);
+		$methodReflector = $reflector->getMethod('getName');
+		if ($methodReflector->isStatic()) {
+			$name = $type::getName();
+		} else {
+			$name = (new $type)->getName();
+		}
+
+		if (!\Doctrine\DBAL\Types\Type::hasType($name)) {
+			\Doctrine\DBAL\Types\Type::addType($name, $type);
+		}
+
 		$this->type = $type;
 		$this->broker = $broker;
 	}


### PR DESCRIPTION
The goal is to use the extension without having to provide a `objectManagerLoader`.

The base functionality was added in https://github.com/phpstan/phpstan-doctrine/pull/253.

Because `EntityColumnRule` uses `DescriptorRegistry` and that uses DBAL's `Type::getTypesMap` we
need to make sure that all types are defined there as well.

To make that easy, I quickly hacked the `ReflectionDescriptor` to automatically register the type.

As a bonus, I also did the `UuidTypeDescriptor`.

Now I can run it without having to instantiate the Symfony container.

@ondrejmirtes This is a POC, what's the best way to address this?