### PR TITLE
Add IDENTITY() type inference support

### DIFF
--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -1152,6 +1152,29 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					FROM		QueryResult\Entities\Many m
 				',
 			],
+			'identity function' => [
+				$this->constantArray([
+					[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
+					[new ConstantIntegerType(2), $this->numericStringOrInt()],
+					[new ConstantIntegerType(3), TypeCombinator::addNull($this->numericStringOrInt())],
+					[new ConstantIntegerType(4), TypeCombinator::addNull(new StringType())],
+					[new ConstantIntegerType(5), TypeCombinator::addNull(new StringType())],
+					[new ConstantIntegerType(6), TypeCombinator::addNull($this->numericStringOrInt())],
+					[new ConstantIntegerType(7), TypeCombinator::addNull(new MixedType())],
+					[new ConstantIntegerType(8), TypeCombinator::addNull($this->numericStringOrInt())],
+				]),
+				'
+					SELECT		IDENTITY(m.oneNull),
+								IDENTITY(m.one),
+								IDENTITY(m.oneDefaultNullability),
+								IDENTITY(m.compoundPk),
+								IDENTITY(m.compoundPk, \'id\'),
+								IDENTITY(m.compoundPk, \'version\'),
+								IDENTITY(m.compoundPkAssoc),
+								IDENTITY(m.compoundPkAssoc, \'version\')
+					FROM		QueryResult\Entities\Many m
+				',
+			],
 			'select nullable association' => [
 				$this->constantArray([
 					[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],

--- a/tests/Type/Doctrine/data/QueryResult/Entities/CompoundPk.php
+++ b/tests/Type/Doctrine/data/QueryResult/Entities/CompoundPk.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace QueryResult\Entities;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embedded as ORMEmbedded;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use QueryResult\Entities\One;
+
+/**
+ * @Entity
+ */
+class CompoundPk
+{
+	/**
+	 * @Column(type="string")
+	 * @Id
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * @Column(type="integer")
+	 * @Id
+	 *
+	 * @var int
+	 */
+	public $version;
+}

--- a/tests/Type/Doctrine/data/QueryResult/Entities/CompoundPkAssoc.php
+++ b/tests/Type/Doctrine/data/QueryResult/Entities/CompoundPkAssoc.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace QueryResult\Entities;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embedded as ORMEmbedded;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use QueryResult\Entities\One;
+
+/**
+ * @Entity
+ */
+class CompoundPkAssoc
+{
+	/**
+	 * @ManyToOne(targetEntity="QueryResult\Entities\One")
+	 * @JoinColumn(nullable=false)
+	 * @Id
+	 *
+	 * @var One
+	 */
+	public $one;
+
+	/**
+	 * @Column(type="integer")
+	 * @Id
+	 *
+	 * @var int
+	 */
+	public $version;
+}

--- a/tests/Type/Doctrine/data/QueryResult/Entities/Many.php
+++ b/tests/Type/Doctrine/data/QueryResult/Entities/Many.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\JoinColumns;
 use Doctrine\ORM\Mapping\ManyToOne;
 
 /**
@@ -78,4 +79,26 @@ class Many
 	 * @var One|null
 	 */
 	public $oneDefaultNullability;
+
+	/**
+	 * @ManyToOne(targetEntity="QueryResult\Entities\CompoundPk")
+	 * @JoinColumns({
+	 *  @JoinColumn(name="compoundPk_id", referencedColumnName="id"),
+	 *  @JoinColumn(name="compoundPk_version", referencedColumnName="version")
+	 * })
+	 *
+	 * @var CompoundPk|null
+	 */
+	public $compoundPk;
+
+	/**
+	 * @ManyToOne(targetEntity="QueryResult\Entities\CompoundPkAssoc")
+	 * @JoinColumns({
+	 *  @JoinColumn(name="compoundPk_one", referencedColumnName="one_id"),
+	 *  @JoinColumn(name="compoundPk_version", referencedColumnName="version")
+	 * })
+	 *
+	 * @var CompoundPkAssoc|null
+	 */
+	public $compoundPkAssoc;
 }


### PR DESCRIPTION
Supports `IDENTITY(a.assoc)` or `IDENTITY(a.assoc, 'id_field')` where `id_field` is the name of one of the id fields of the target class.

Does not support `IDENTITY(a.assoc)` when the target id field is also an association (this is inferred to mixed).