### PR TITLE
Add allowNullablePropertyForRequiredField mention into the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This extension provides following features:
 * Provides correct return type for `Doctrine\ORM\EntityManager::find`, `getReference` and `getPartialReference` when `Foo::class` entity class name is provided as the first argument
 * Adds missing `matching` method on `Doctrine\Common\Collections\Collection`. This can be turned off by setting `parameters.doctrine.allCollectionsSelectable` to `false`.
 * Also supports Doctrine ODM.
-* Analysis of discrepancies between entity column types and property field types.
+* Analysis of discrepancies between entity column types and property field types. This can be relaxed with the `allowNullablePropertyForRequiredField: true` setting.
 
 ## Installation
 


### PR DESCRIPTION
Hi @ondrejmirtes 

Some days ago, the `allowNullablePropertyForRequiredField` setting was added https://github.com/phpstan/phpstan-doctrine/pull/208 but there is currently no mention about it in the readme. I think something should be added.

I don't know if you just want a mention like I did or something more explicit or a whole readme section about it.