### PR TITLE
Document that `EntityManager::flush()` can throw DBAL's `UniqueConstraintViolationException`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -18,6 +18,7 @@ parameters:
 			- Doctrine\ORM\Query
 	stubFiles:
 		- stubs/Criteria.stub
+		- stubs/DBAL/Exception/UniqueConstraintViolationException.stub
 		- stubs/DocumentManager.stub
 		- stubs/DocumentRepository.stub
 		- stubs/EntityManager.stub
@@ -38,6 +39,7 @@ parameters:
 		- stubs/ORM/AbstractQuery.stub
 		- stubs/ORM/Mapping/ClassMetadata.stub
 		- stubs/ORM/Mapping/ClassMetadataInfo.stub
+		- stubs/ORM/ORMException.stub
 		- stubs/ORM/Query.stub
 		- stubs/Persistence/Mapping/ClassMetadata.stub
 		- stubs/ServiceDocumentRepository.stub

--- a/stubs/DBAL/Exception/UniqueConstraintViolationException.stub
+++ b/stubs/DBAL/Exception/UniqueConstraintViolationException.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL\Exception;
+
+class UniqueConstraintViolationException extends \Exception
+{
+
+}

--- a/stubs/EntityManager.stub
+++ b/stubs/EntityManager.stub
@@ -56,4 +56,13 @@ class EntityManager implements EntityManagerInterface
 	 */
 	public function copy($entity, $deep = false);
 
+	/**
+     * @param object|object[]|null $entity
+     * @return void
+     *
+     * @throws ORMException
+     * @throws \Doctrine\DBAL\Exception\UniqueConstraintViolationException
+     */
+    public function flush($entity = null);
+
 }

--- a/stubs/ORM/ORMException.stub
+++ b/stubs/ORM/ORMException.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\ORM;
+
+class ORMException extends \Exception
+{
+
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan-doctrine/issues/295 and as mentioned there - there is no intention in adding it in Doctrine ORM and I also think it should not be there. So either PHPStan has to understand that the exception can go from DBAL to `flush()` or we have to help him and that is why I think it should be in this repo.