### PR TITLE
Test that `UniqueConstraintViolationException` from `EntityManager::flush()` is not marked as dead catch

### DIFF
--- a/tests/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Exceptions;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CatchWithUnthrownExceptionRule>
+ */
+class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return self::getContainer()->getByType(CatchWithUnthrownExceptionRule::class);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/unthrown-exception.php'], []);
+	}
+
+}

--- a/tests/Rules/Exceptions/data/unthrown-exception.php
+++ b/tests/Rules/Exceptions/data/unthrown-exception.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace UnthrownException;
+
+class FooFacade
+{
+
+	/** @var \Doctrine\ORM\EntityManager */
+	private $entityManager;
+
+	public function doFoo(): void
+	{
+		try {
+			$this->entityManager->flush();
+		} catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
+			// pass
+		}
+	}
+
+}


### PR DESCRIPTION
Test for https://github.com/phpstan/phpstan-doctrine/pull/313 .