### PR TITLE
Dynamic return types for some Expr methods - Part 2

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -39,6 +39,7 @@ parameters:
 		- stubs/ORM/Mapping/ClassMetadata.stub
 		- stubs/ORM/Mapping/ClassMetadataInfo.stub
 		- stubs/ORM/ORMException.stub
+		- stubs/ORM/Query/Expr.stub
 		- stubs/ORM/Query.stub
 		- stubs/ORM/Query/Expr/Comparison.stub
 		- stubs/ORM/Query/Expr/Composite.stub

--- a/src/Type/Doctrine/QueryBuilder/Expr/ExpressionBuilderDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/Expr/ExpressionBuilderDynamicReturnTypeExtension.php
@@ -46,7 +46,7 @@ class ExpressionBuilderDynamicReturnTypeExtension implements DynamicMethodReturn
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		$defaultReturnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+		$defaultReturnType = ParametersAcceptorSelector::selectFromArgs($scope, $methodCall->getArgs(), $methodReflection->getVariants())->getReturnType();
 
 		$objectManager = $this->objectMetadataResolver->getObjectManager();
 		if ($objectManager === null) {

--- a/stubs/ORM/Query/Expr.stub
+++ b/stubs/ORM/Query/Expr.stub
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\ORM\Query;
+
+class Expr
+{
+
+	/**
+	 * @param string $x
+	 * @return ($x is literal-string ? literal-string&non-empty-string : string)
+	 */
+	public function isNull($x)
+	{
+	}
+
+	/**
+	 * @param string $x
+	 * @return ($x is literal-string ? literal-string&non-empty-string : string)
+	 */
+	public function isNotNull($x)
+	{
+	}
+
+	/**
+	 * @param string $val
+	 * @param string $x
+	 * @param string $y
+	 * @return ($val is literal-string ? ($x is literal-string ? ($y is literal-string ? literal-string&non-empty-string : string) : string) : string)
+	 */
+	public function between($val, $x, $y)
+	{
+	}
+
+}

--- a/tests/Type/Doctrine/QueryBuilder/Expr/ExpressionBuilderDynamicReturnTypeExtensionNoObjectManagerTest.php
+++ b/tests/Type/Doctrine/QueryBuilder/Expr/ExpressionBuilderDynamicReturnTypeExtensionNoObjectManagerTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine\QueryBuilder\Expr;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class ExpressionBuilderDynamicReturnTypeExtensionNoObjectManagerTest extends TypeInferenceTestCase
+{
+
+	/** @return iterable<mixed> */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/../../data/QueryResult/expressionBuilderGetQueryNoObjectManager.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	/** @return string[] */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../data/QueryResult/config-without-object-manager.neon'];
+	}
+
+}

--- a/tests/Type/Doctrine/data/QueryResult/config-without-object-manager.neon
+++ b/tests/Type/Doctrine/data/QueryResult/config-without-object-manager.neon
@@ -1,0 +1,2 @@
+includes:
+	- ../../../../../extension.neon

--- a/tests/Type/Doctrine/data/QueryResult/expressionBuilderGetQueryNoObjectManager.php
+++ b/tests/Type/Doctrine/data/QueryResult/expressionBuilderGetQueryNoObjectManager.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\QueryBuilder;
 use QueryResult\Entities\Many;
 use function PHPStan\Testing\assertType;
 
-class ExpressionBuilderGetQuery
+class ExpressionBuilderGetQueryNoObjectManager
 {
 	private function nonLiteralString(string $value): string {
 		return $value; // Using the 'string' return type to provide a non `literal-string`, e.g. $_POST['field'];
@@ -17,7 +17,7 @@ class ExpressionBuilderGetQuery
 	public function isNullLiteralString(EntityManagerInterface $em): void
 	{
 		$result = $em->createQueryBuilder()->expr()->isNull('field');
-		assertType("'field IS NULL'", $result); // A ConstantStringType isLiteralString
+		assertType('literal-string&non-empty-string', $result);
 	}
 
 	public function isNullNonLiteralString(EntityManagerInterface $em): void
@@ -30,7 +30,7 @@ class ExpressionBuilderGetQuery
 	public function isNotNullLiteralString(EntityManagerInterface $em): void
 	{
 		$result = $em->createQueryBuilder()->expr()->isNotNull('field');
-		assertType("'field IS NOT NULL'", $result); // A ConstantStringType isLiteralString
+		assertType('literal-string&non-empty-string', $result);
 	}
 
 	public function isNotNullNonLiteralString(EntityManagerInterface $em): void
@@ -43,7 +43,7 @@ class ExpressionBuilderGetQuery
 	public function betweenLiteralString(EntityManagerInterface $em): void
 	{
 		$result = $em->createQueryBuilder()->expr()->between('field', "'value_1'", "'value_2'");
-		assertType("'field BETWEEN \'value_1\' AND \'value_2\''", $result); // A ConstantStringType isLiteralString
+		assertType('literal-string&non-empty-string', $result);
 	}
 
 	public function betweenNonLiteralString1(EntityManagerInterface $em): void


### PR DESCRIPTION
Continuing on from [PR 298](https://github.com/phpstan/phpstan-doctrine/pull/298), for [Issue 294](https://github.com/phpstan/phpstan-doctrine/issues/294).

I'm starting with:

- Failing tests, confirming these functions don't return a `literal-string` when there is no Object Manager.
- Changed the requirements to `phpstan/phpstan:^1.6`.
- Changed `selectSingle` to `selectFromArgs`.

I'll continue this next week, but thought I should upload what I've got so far just incase I'm going in the wrong direction.

---

[Previous Diff](https://github.com/phpstan/phpstan-doctrine/pull/298/commits/2f6f12fa8fbfd8a702e933152878f59f08f29bc1).

"Implement the logic in **stubs** with the help of conditional return types"... "The conditional return type for the methods would look like this: `@return ($x is literal-string ? literal-string : string)`"