### PR TITLE
@Version field is always written

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,9 +15,6 @@ parameters:
 		- tests/*/data-php-*/*
 		- tests/Rules/Doctrine/ORM/entity-manager.php
 
-	propertyAlwaysWrittenTags:
-		- Version
-
 	reportUnmatchedIgnoredErrors: false
 
 	ignoreErrors:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,9 @@ parameters:
 		- tests/*/data-php-*/*
 		- tests/Rules/Doctrine/ORM/entity-manager.php
 
+	propertyAlwaysWrittenTags:
+        - Version
+
 	reportUnmatchedIgnoredErrors: false
 
 	ignoreErrors:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,7 @@ parameters:
 		- tests/Rules/Doctrine/ORM/entity-manager.php
 
 	propertyAlwaysWrittenTags:
-        - Version
+		- Version
 
 	reportUnmatchedIgnoredErrors: false
 

--- a/src/Rules/Doctrine/ORM/PropertiesExtension.php
+++ b/src/Rules/Doctrine/ORM/PropertiesExtension.php
@@ -51,6 +51,10 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 			return false;
 		}
 
+		if ($metadata->versionField === $propertyName) {
+			return true;
+		}
+
 		try {
 			$identifiers = $metadata->getIdentifierFieldNames();
 		} catch (Throwable $e) {

--- a/tests/Rules/Doctrine/ORM/data/MyEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/MyEntity.php
@@ -20,6 +20,12 @@ class MyEntity
 	private $id;
 
 	/**
+	 * @ORM\Column(type="integer")
+     * @ORM\Version
+	 */
+	private $version;
+
+	/**
 	 * @var string
 	 * @ORM\Column(type="string")
 	 */


### PR DESCRIPTION
Hi, I believe there is missing condition somewhere that would say that optimistic lock field, managed by ORM is always written.