### PR TITLE
Add literal-string check for andWhere

### DIFF
--- a/stubs/bleedingEdge/ORM/QueryBuilder.stub
+++ b/stubs/bleedingEdge/ORM/QueryBuilder.stub
@@ -143,5 +143,14 @@ class QueryBuilder
 	{
 
 	}
+	
+	/**
+	 * @param literal-string|object|array<mixed> $predicates
+	 * @return $this
+	 */
+	public function andWhere($predicates)
+	{
+
+	}
 
 }


### PR DESCRIPTION
This was introduced for where, but andWhere is working the same way.