### PR TITLE
Precise getRootAliases return type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -24,7 +24,6 @@ parameters:
 		- stubs/EntityManager.stub
 		- stubs/EntityManagerDecorator.stub
 		- stubs/EntityManagerInterface.stub
-		- stubs/EntityRepository.stub
 		- stubs/ServiceEntityRepository.stub
 		- stubs/MongoClassMetadataInfo.stub
 

--- a/src/Stubs/Doctrine/StubFilesExtensionLoader.php
+++ b/src/Stubs/Doctrine/StubFilesExtensionLoader.php
@@ -28,6 +28,7 @@ class StubFilesExtensionLoader implements StubFilesExtension
 
 		return [
 			$path . '/ORM/QueryBuilder.stub',
+			$path . '/EntityRepository.stub',
 		];
 	}
 

--- a/stubs/ORM/QueryBuilder.stub
+++ b/stubs/ORM/QueryBuilder.stub
@@ -5,20 +5,20 @@ namespace Doctrine\ORM;
 class QueryBuilder
 {
 
-    /**
-     * @param \Doctrine\Common\Collections\ArrayCollection<array-key, mixed>|array<mixed> $parameters
-     * @return static
-     */
-    public function setParameters($parameters)
-    {
+	/**
+	 * @param \Doctrine\Common\Collections\ArrayCollection<array-key, mixed>|array<mixed> $parameters
+	 * @return static
+	 */
+	public function setParameters($parameters)
+	{
 
-    }
+	}
 
-    /**
-     * @return Query<mixed>
-     */
-    public function getQuery()
-    {
-    }
+	/**
+	 * @return Query<mixed>
+	 */
+	public function getQuery()
+	{
+	}
 
 }

--- a/stubs/ORM/QueryBuilder.stub
+++ b/stubs/ORM/QueryBuilder.stub
@@ -5,19 +5,27 @@ namespace Doctrine\ORM;
 class QueryBuilder
 {
 
-	/**
-	 * @param \Doctrine\Common\Collections\ArrayCollection<array-key, mixed>|array<mixed> $parameters
-	 * @return static
-	 */
-	public function setParameters($parameters)
-	{
+    /**
+     * @param \Doctrine\Common\Collections\ArrayCollection<array-key, mixed>|array<mixed> $parameters
+     * @return static
+     */
+    public function setParameters($parameters)
+    {
 
-	}
+    }
 
     /**
      * @return Query<mixed>
      */
     public function getQuery()
     {
+    }
+
+    /**
+    * @return list<literal-string>
+    */
+    public function getRootAliases()
+    {
+
     }
 }

--- a/stubs/ORM/QueryBuilder.stub
+++ b/stubs/ORM/QueryBuilder.stub
@@ -21,11 +21,4 @@ class QueryBuilder
     {
     }
 
-    /**
-    * @return list<literal-string>
-    */
-    public function getRootAliases()
-    {
-
-    }
 }

--- a/stubs/bleedingEdge/EntityRepository.stub
+++ b/stubs/bleedingEdge/EntityRepository.stub
@@ -1,0 +1,74 @@
+<?php
+
+namespace Doctrine\ORM;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Persistence\ObjectRepository;
+
+/**
+ * @template TEntityClass of object
+ * @implements ObjectRepository<TEntityClass>
+ */
+class EntityRepository implements ObjectRepository
+{
+
+	/** @var class-string<TEntityClass> */
+	protected $_entityName;
+
+	/**
+	 * @phpstan-param mixed $id
+	 * @phpstan-param int|null $lockMode
+	 * @phpstan-param int|null $lockVersion
+	 * @phpstan-return TEntityClass|null
+	 */
+	public function find($id, $lockMode = null, $lockVersion = null);
+
+	/**
+	 * @phpstan-return TEntityClass[]
+	 */
+	public function findAll();
+
+	/**
+	 * @phpstan-param array<string, mixed> $criteria
+	 * @phpstan-param array<string, string>|null $orderBy
+	 * @phpstan-param int|null $limit
+	 * @phpstan-param int|null $offset
+	 * @phpstan-return TEntityClass[]
+	 */
+	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
+
+	/**
+	 * @phpstan-param array<string, mixed> $criteria The criteria.
+	 * @phpstan-param array<string, string>|null $orderBy
+	 * @phpstan-return TEntityClass|null
+	 */
+	public function findOneBy(array $criteria, array $orderBy = null);
+
+	/**
+	 * @phpstan-return class-string<TEntityClass>
+	 */
+	public function getClassName();
+
+	/**
+	 * @phpstan-return class-string<TEntityClass>
+	 */
+	protected function getEntityName();
+
+	/**
+	 * @param \Doctrine\Common\Collections\Criteria $criteria
+	 *
+	 * @return \Doctrine\Common\Collections\Collection
+	 *
+	 * @psalm-return \Doctrine\Common\Collections\Collection<int, TEntityClass>
+	 */
+	public function matching(Criteria $criteria);
+
+	/**
+     * @param literal-string      $alias
+     * @param literal-string|null $indexBy
+     *
+     * @return QueryBuilder
+     */
+    public function createQueryBuilder($alias, $indexBy = null);
+
+}

--- a/stubs/bleedingEdge/EntityRepository.stub
+++ b/stubs/bleedingEdge/EntityRepository.stub
@@ -64,11 +64,11 @@ class EntityRepository implements ObjectRepository
 	public function matching(Criteria $criteria);
 
 	/**
-     * @param literal-string      $alias
-     * @param literal-string|null $indexBy
-     *
-     * @return QueryBuilder
-     */
-    public function createQueryBuilder($alias, $indexBy = null);
+	 * @param literal-string      $alias
+	 * @param literal-string|null $indexBy
+	 *
+	 * @return QueryBuilder
+	 */
+	public function createQueryBuilder($alias, $indexBy = null);
 
 }

--- a/stubs/bleedingEdge/ORM/QueryBuilder.stub
+++ b/stubs/bleedingEdge/ORM/QueryBuilder.stub
@@ -2,6 +2,8 @@
 
 namespace Doctrine\ORM;
 
+use Doctrine\ORM\Query\Expr;
+
 class QueryBuilder
 {
 

--- a/stubs/bleedingEdge/ORM/QueryBuilder.stub
+++ b/stubs/bleedingEdge/ORM/QueryBuilder.stub
@@ -22,9 +22,25 @@ class QueryBuilder
 	}
 
 	/**
+	 * @return literal-string
+	 */
+	public function getRootAlias()
+	{
+
+	}
+
+	/**
 	 * @return list<literal-string>
 	 */
 	public function getRootAliases()
+	{
+
+	}
+
+	/**
+	 * @return list<literal-string>
+	 */
+	public function getAllAlias()
 	{
 
 	}

--- a/stubs/bleedingEdge/ORM/QueryBuilder.stub
+++ b/stubs/bleedingEdge/ORM/QueryBuilder.stub
@@ -21,6 +21,94 @@ class QueryBuilder
 
 	}
 
+    /**
+     * @param string                                                                                  $dqlPartName
+     * @psalm-param literal-string|object|list<literal-string>|array{join: array<int|string, object>} $dqlPart
+     * @param bool                                                                                    $append
+     *
+     * @return $this
+     */
+    public function add($dqlPartName, $dqlPart, $append = false)
+    {
+
+    }
+
+    /**
+     * @param literal-string|null $delete
+     * @param literal-string|null $alias
+     *
+     * @return $this
+     */
+    public function delete($delete = null, $alias = null)
+    {
+
+    }
+
+    /**
+     * @param literal-string|null $update
+     * @param literal-string|null $alias
+     *
+     * @return $this
+     */
+    public function update($update = null, $alias = null)
+    {
+
+    }
+
+    /**
+     * @param literal-string      $from
+     * @param literal-string      $alias
+     * @param literal-string|null $indexBy
+     *
+     * @return $this
+     */
+    public function from($from, $alias, $indexBy = null)
+    {
+
+    }
+
+    /**
+     * @param literal-string                                     $join
+     * @param literal-string                                     $alias
+     * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
+     * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
+     * @param literal-string|null                                $indexBy
+     *
+     * @return $this
+     */
+    public function innerJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+
+    }
+
+    /**
+     * @param literal-string                                     $join
+     * @param literal-string                                     $alias
+     * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
+     * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
+     * @param literal-string|null                                $indexBy
+     *
+     * @return $this
+     */
+    public function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+
+    }
+
+    /**
+     * @param literal-string                                     $join
+     * @param literal-string                                     $alias
+     * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
+     * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
+     * @param literal-string|null                                $indexBy
+     *
+     * @return $this
+     */
+    public function join($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+
+    }
+
 	/**
 	 * @return literal-string
 	 */

--- a/stubs/bleedingEdge/ORM/QueryBuilder.stub
+++ b/stubs/bleedingEdge/ORM/QueryBuilder.stub
@@ -21,93 +21,93 @@ class QueryBuilder
 
 	}
 
-    /**
-     * @param string                                                                                  $dqlPartName
-     * @psalm-param literal-string|object|list<literal-string>|array{join: array<int|string, object>} $dqlPart
-     * @param bool                                                                                    $append
-     *
-     * @return $this
-     */
-    public function add($dqlPartName, $dqlPart, $append = false)
-    {
+	/**
+	 * @param string                                                                            $dqlPartName
+	 * @param literal-string|object|list<literal-string>|array{join: array<int|string, object>} $dqlPart
+	 * @param bool                                                                              $append
+	 *
+	 * @return $this
+	 */
+	public function add($dqlPartName, $dqlPart, $append = false)
+	{
 
-    }
+	}
 
-    /**
-     * @param literal-string|null $delete
-     * @param literal-string|null $alias
-     *
-     * @return $this
-     */
-    public function delete($delete = null, $alias = null)
-    {
+	/**
+	 * @param literal-string|null $delete
+	 * @param literal-string|null $alias
+	 *
+	 * @return $this
+	 */
+	public function delete($delete = null, $alias = null)
+	{
 
-    }
+	}
 
-    /**
-     * @param literal-string|null $update
-     * @param literal-string|null $alias
-     *
-     * @return $this
-     */
-    public function update($update = null, $alias = null)
-    {
+	/**
+	 * @param literal-string|null $update
+	 * @param literal-string|null $alias
+	 *
+	 * @return $this
+	 */
+	public function update($update = null, $alias = null)
+	{
 
-    }
+	}
 
-    /**
-     * @param literal-string      $from
-     * @param literal-string      $alias
-     * @param literal-string|null $indexBy
-     *
-     * @return $this
-     */
-    public function from($from, $alias, $indexBy = null)
-    {
+	/**
+	 * @param literal-string      $from
+	 * @param literal-string      $alias
+	 * @param literal-string|null $indexBy
+	 *
+	 * @return $this
+	 */
+	public function from($from, $alias, $indexBy = null)
+	{
 
-    }
+	}
 
-    /**
-     * @param literal-string                                     $join
-     * @param literal-string                                     $alias
-     * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
-     * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
-     * @param literal-string|null                                $indexBy
-     *
-     * @return $this
-     */
-    public function innerJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
-    {
+	/**
+	 * @param literal-string                                     $join
+	 * @param literal-string                                     $alias
+	 * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
+	 * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
+	 * @param literal-string|null                                $indexBy
+	 *
+	 * @return $this
+	 */
+	public function innerJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+	{
 
-    }
+	}
 
-    /**
-     * @param literal-string                                     $join
-     * @param literal-string                                     $alias
-     * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
-     * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
-     * @param literal-string|null                                $indexBy
-     *
-     * @return $this
-     */
-    public function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
-    {
+	/**
+	 * @param literal-string                                     $join
+	 * @param literal-string                                     $alias
+	 * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
+	 * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
+	 * @param literal-string|null                                $indexBy
+	 *
+	 * @return $this
+	 */
+	public function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+	{
 
-    }
+	}
 
-    /**
-     * @param literal-string                                     $join
-     * @param literal-string                                     $alias
-     * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
-     * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
-     * @param literal-string|null                                $indexBy
-     *
-     * @return $this
-     */
-    public function join($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
-    {
+	/**
+	 * @param literal-string                                     $join
+	 * @param literal-string                                     $alias
+	 * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
+	 * @param literal-string|Expr\Comparison|Expr\Composite|null $condition
+	 * @param literal-string|null                                $indexBy
+	 *
+	 * @return $this
+	 */
+	public function join($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+	{
 
-    }
+	}
 
 	/**
 	 * @return literal-string

--- a/stubs/bleedingEdge/ORM/QueryBuilder.stub
+++ b/stubs/bleedingEdge/ORM/QueryBuilder.stub
@@ -22,6 +22,14 @@ class QueryBuilder
 	}
 
 	/**
+	 * @return list<literal-string>
+	 */
+	public function getRootAliases()
+	{
+
+	}
+
+	/**
 	 * @param literal-string|object|array<mixed> $predicates
 	 * @return $this
 	 */


### PR DESCRIPTION
This allow
```
$rootAlias = current($query->getQueryBuilder()->getRootAliases());

$queryBuilder->where($rootAlias . '.statusId IN (:statusIds)')
```