### PR TITLE
Add failing tests for `MissingReadOnlyPropertyAssignRule`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.2 || ^8.0",
-		"phpstan/phpstan": "^1.7.0"
+		"phpstan/phpstan": "^1.7.3"
 	},
 	"conflict": {
 		"doctrine/collections": "<1.0",

--- a/src/Rules/Doctrine/ORM/PropertiesExtension.php
+++ b/src/Rules/Doctrine/ORM/PropertiesExtension.php
@@ -44,34 +44,15 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 			return false;
 		}
 
-		if ($this->isGeneratedIdentifier($metadata, $propertyName)) {
-			return true;
-		}
-
 		if ($metadata->isReadOnly && !$declaringClass->hasConstructor()) {
 			return true;
-		}
-
-		if ($metadata->isIdentifierNatural()) {
-			return false;
 		}
 
 		if ($metadata->versionField === $propertyName) {
 			return true;
 		}
 
-		try {
-			$identifiers = $metadata->getIdentifierFieldNames();
-		} catch (Throwable $e) {
-			$mappingException = 'Doctrine\ORM\Mapping\MappingException';
-			if (!$e instanceof $mappingException) {
-				throw $e;
-			}
-
-			return false;
-		}
-
-		return in_array($propertyName, $identifiers, true);
+		return $this->isGeneratedIdentifier($metadata, $propertyName);
 	}
 
 	public function isInitialized(PropertyReflection $property, string $propertyName): bool
@@ -96,11 +77,20 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 
 	private function isGeneratedIdentifier(ClassMetadataInfo $metadata, string $propertyName): bool
 	{
-		if (!in_array($propertyName, $metadata->getIdentifierFieldNames(), true)) {
+		if ($metadata->isIdentifierNatural()) {
 			return false;
 		}
 
-		return $metadata->generatorType !== ClassMetadataInfo::GENERATOR_TYPE_NONE;
+		try {
+			return in_array($propertyName, $metadata->getIdentifierFieldNames(), true);
+		} catch (Throwable $e) {
+			$mappingException = 'Doctrine\ORM\Mapping\MappingException';
+			if (!$e instanceof $mappingException) {
+				throw $e;
+			}
+
+			return false;
+		}
 	}
 
 }

--- a/src/Rules/Doctrine/ORM/PropertiesExtension.php
+++ b/src/Rules/Doctrine/ORM/PropertiesExtension.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Doctrine\ORM;
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
 use PHPStan\Type\Doctrine\ObjectMetadataResolver;
@@ -43,6 +44,10 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 			return false;
 		}
 
+		if ($this->isGeneratedIdentifier($metadata, $propertyName)) {
+			return true;
+		}
+
 		if ($metadata->isReadOnly && !$declaringClass->hasConstructor()) {
 			return true;
 		}
@@ -82,7 +87,20 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 			return false;
 		}
 
+		if ($this->isGeneratedIdentifier($metadata, $propertyName)) {
+			return true;
+		}
+
 		return $metadata->isReadOnly && !$declaringClass->hasConstructor();
+	}
+
+	private function isGeneratedIdentifier(ClassMetadataInfo $metadata, string $propertyName): bool
+	{
+		if (!in_array($propertyName, $metadata->getIdentifierFieldNames(), true)) {
+			return false;
+		}
+
+		return $metadata->generatorType !== ClassMetadataInfo::GENERATOR_TYPE_NONE;
 	}
 
 }

--- a/tests/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
+++ b/tests/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\DeadCode;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<UnusedPrivatePropertyRule>
+ */
+class UnusedPrivatePropertyRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return self::getContainer()->getByType(UnusedPrivatePropertyRule::class);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../../extension.neon'];
+	}
+
+	public function testRule(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			self::markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->analyse([__DIR__ . '/data/unused-private-property.php'], [
+			[
+				'Property UnusedPrivateProperty\EntityWithAGeneratedId::$unused is never written, only read.',
+				23,
+				'See: https://phpstan.org/developing-extensions/always-read-written-properties',
+			],
+			[
+				'Property UnusedPrivateProperty\EntityWithAGeneratedId::$unused2 is unused.',
+				25,
+				'See: https://phpstan.org/developing-extensions/always-read-written-properties',
+			],
+			[
+				'Property UnusedPrivateProperty\ReadOnlyEntityWithConstructor::$id is never written, only read.',
+				53,
+				'See: https://phpstan.org/developing-extensions/always-read-written-properties',
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/DeadCode/data/unused-private-property.php
+++ b/tests/Rules/DeadCode/data/unused-private-property.php
@@ -1,0 +1,59 @@
+<?php // lint >= 7.4
+
+namespace UnusedPrivateProperty;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class EntityWithAGeneratedId
+{
+
+	/**
+	 * @ORM\Id
+	 * @ORM\GeneratedValue
+	 * @ORM\Column
+	 */
+	private int $id; // ok, ID is generated
+
+	/**
+	 * @ORM\Column
+	 */
+	private int $unused;
+
+	private int $unused2;
+
+}
+
+/**
+ * @ORM\Entity(readOnly=true)
+ */
+class ReadOnlyEntity
+{
+
+	/**
+	 * @ORM\Id
+	 * @ORM\Column
+	 */
+	private int $id; // ok, entity is read only
+
+}
+
+/**
+ * @ORM\Entity(readOnly=true)
+ */
+class ReadOnlyEntityWithConstructor
+{
+
+	/**
+	 * @ORM\Id
+	 * @ORM\Column
+	 */
+	private int $id;
+
+	public function __construct()
+	{
+	}
+
+}

--- a/tests/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<MissingReadOnlyByPhpDocPropertyAssignRule>
+ */
+class MissingReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return self::getContainer()->getByType(MissingReadOnlyByPhpDocPropertyAssignRule::class);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../../extension.neon'];
+	}
+
+	public function testRule(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			self::markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->analyse([__DIR__ . '/data/missing-readonly-property-assign-phpdoc.php'], []);
+	}
+
+}

--- a/tests/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -28,7 +28,20 @@ class MissingReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 			self::markTestSkipped('Test requires PHP 7.4.');
 		}
 
-		$this->analyse([__DIR__ . '/data/missing-readonly-property-assign-phpdoc.php'], []);
+		$this->analyse([__DIR__ . '/data/missing-readonly-property-assign-phpdoc.php'], [
+			[
+				'Class MissingReadOnlyPropertyAssignPhpDoc\EntityWithAGeneratedId has an uninitialized @readonly property $unassigned. Assign it in the constructor.',
+				25,
+			],
+			[
+				'@readonly property MissingReadOnlyPropertyAssignPhpDoc\EntityWithAGeneratedId::$doubleAssigned is already assigned.',
+				36,
+			],
+			[
+				'Class MissingReadOnlyPropertyAssignPhpDoc\ReadOnlyEntityWithConstructor has an uninitialized @readonly property $id. Assign it in the constructor.',
+				67,
+			],
+		]);
 	}
 
 }

--- a/tests/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<MissingReadOnlyPropertyAssignRule>
+ */
+class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return self::getContainer()->getByType(MissingReadOnlyPropertyAssignRule::class);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../../extension.neon'];
+	}
+
+	public function testRule(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			self::markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/missing-readonly-property-assign.php'], []);
+	}
+
+}

--- a/tests/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -28,7 +28,20 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 			self::markTestSkipped('Test requires PHP 8.1.');
 		}
 
-		$this->analyse([__DIR__ . '/data/missing-readonly-property-assign.php'], []);
+		$this->analyse([__DIR__ . '/data/missing-readonly-property-assign.php'], [
+			[
+				'Class MissingReadOnlyPropertyAssign\EntityWithAGeneratedId has an uninitialized readonly property $unassigned. Assign it in the constructor.',
+				17,
+			],
+			[
+				'Readonly property MissingReadOnlyPropertyAssign\EntityWithAGeneratedId::$doubleAssigned is already assigned.',
+				25,
+			],
+			[
+				'Class MissingReadOnlyPropertyAssign\ReadOnlyEntityWithConstructor has an uninitialized readonly property $id. Assign it in the constructor.',
+				46,
+			],
+		]);
 	}
 
 }

--- a/tests/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
+++ b/tests/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
@@ -1,0 +1,21 @@
+<?php // lint >= 7.4
+
+namespace MissingReadOnlyPropertyAssignPhpDoc;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Entity
+{
+
+	/**
+	 * @ORM\Id
+	 * @ORM\GeneratedValue
+	 * @ORM\Column
+	 * @readonly
+	 */
+	private int $id; // ok because of PropertiesExtension
+
+}

--- a/tests/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
+++ b/tests/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class Entity
+class EntityWithAGeneratedId
 {
 
 	/**
@@ -16,6 +16,58 @@ class Entity
 	 * @ORM\Column
 	 * @readonly
 	 */
-	private int $id; // ok because of PropertiesExtension
+	private int $id; // ok, ID is generated
+
+	/**
+	 * @ORM\Column
+	 * @readonly
+	 */
+	private int $unassigned;
+
+	/**
+	 * @ORM\Column
+	 * @readonly
+	 */
+	private int $doubleAssigned;
+
+	public function __construct(int $doubleAssigned)
+	{
+		$this->doubleAssigned = $doubleAssigned;
+		$this->doubleAssigned = 17;
+	}
+
+}
+
+/**
+ * @ORM\Entity(readOnly=true)
+ */
+class ReadOnlyEntity
+{
+
+	/**
+	 * @ORM\Id
+	 * @ORM\Column
+	 * @readonly
+	 */
+	private int $id; // ok, entity is read only
+
+}
+
+/**
+ * @ORM\Entity(readOnly=true)
+ */
+class ReadOnlyEntityWithConstructor
+{
+
+	/**
+	 * @ORM\Id
+	 * @ORM\Column
+	 * @readonly
+	 */
+	private int $id;
+
+	public function __construct()
+	{
+	}
 
 }

--- a/tests/Rules/Properties/data/missing-readonly-property-assign.php
+++ b/tests/Rules/Properties/data/missing-readonly-property-assign.php
@@ -5,12 +5,48 @@ namespace MissingReadOnlyPropertyAssign;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-class Entity
+class EntityWithAGeneratedId
 {
 
 	#[ORM\Id]
 	#[ORM\GeneratedValue]
 	#[ORM\Column]
-	private readonly int $id; // ok because of PropertiesExtension
+	private readonly int $id; // ok, ID is generated
+
+	#[ORM\Column]
+	private readonly int $unassigned;
+
+	#[ORM\Column]
+	private readonly int $doubleAssigned;
+
+	public function __construct(int $doubleAssigned)
+	{
+		$this->doubleAssigned = $doubleAssigned;
+		$this->doubleAssigned = 17;
+	}
+
+}
+
+#[ORM\Entity(null, true)]
+class ReadOnlyEntity
+{
+
+	#[ORM\Id]
+	#[ORM\Column]
+	private readonly int $id; // ok, entity is readonly
+
+}
+
+#[ORM\Entity(null, true)]
+class ReadOnlyEntityWithConstructor
+{
+
+	#[ORM\Id]
+	#[ORM\Column]
+	private readonly int $id;
+
+	public function __construct()
+	{
+	}
 
 }

--- a/tests/Rules/Properties/data/missing-readonly-property-assign.php
+++ b/tests/Rules/Properties/data/missing-readonly-property-assign.php
@@ -1,0 +1,16 @@
+<?php // lint >= 8.1
+
+namespace MissingReadOnlyPropertyAssign;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Entity
+{
+
+	#[ORM\Id]
+	#[ORM\GeneratedValue]
+	#[ORM\Column]
+	private readonly int $id; // ok because of PropertiesExtension
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7337

Looks like the problem is actually here in `PropertiesExtension` (which is now used at least). https://github.com/phpstan/phpstan-doctrine/blob/1.3.6/src/Rules/Doctrine/ORM/PropertiesExtension.php#L85 returns always `false`, because `$metadata->isReadOnly` (which marks if this is a Doctrine readonly entity?) is already false.

Does this need another early exit dealing with native readonly or smth like that? I gave it a shot, but don't know much about this here. Feel free to finish it :)