### PR TITLE
phpcs: Disallow trailing commas in function calls, declarations, use list

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -79,6 +79,11 @@
 	<rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
 	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
 	<rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+	<!-- Disallow trailing comma in function calls, since this breaks on PHP < 7.3 -->
+	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall"/>
+	<!-- Disallow trailing comma in closure use and function declarations, since this breaks on PHP < 8.0 -->
+	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse" />
+	<rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration" />
 	<!--<rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>-->
 	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">


### PR DESCRIPTION
I'm always getting trailing comma errors when submitting PRs on phpstan-doctrine because of the PHP 7.2 support.

It would help a lot if `make cs` would detect these problems.

This PR adds 3 rules to phpcs to do exactly this.

Ideally `make lint` would detect these problems instead, but making it run with PHP 7.2 on everyone's machine is much more involved.