### PR TITLE
Use a @template for countDistinct

### DIFF
--- a/stubs/ORM/Query/Expr.stub
+++ b/stubs/ORM/Query/Expr.stub
@@ -31,4 +31,12 @@ class Expr
 	{
 	}
 
+	/**
+	 * @template T of string
+	 * @param T ...$x
+	 * @return (T is literal-string ? literal-string : string)
+	 */
+	public function countDistinct(...$x) {
+	}
+
 }

--- a/tests/Type/Doctrine/data/QueryResult/expressionBuilderGetQuery.php
+++ b/tests/Type/Doctrine/data/QueryResult/expressionBuilderGetQuery.php
@@ -67,6 +67,44 @@ class ExpressionBuilderGetQuery
 		assertType('string', $result);
 	}
 
+	public function countDistinctLiteralString(EntityManagerInterface $em): void
+	{
+		$result = $em->createQueryBuilder()->expr()->countDistinct('A', 'B', 'C');
+		assertType("'COUNT(DISTINCT A, B, C)'", $result); // A ConstantStringType isLiteralString
+	}
+
+	public function countDistinctNonLiteralString1(EntityManagerInterface $em): void
+	{
+		$value = $this->nonLiteralString('A');
+		$result = $em->createQueryBuilder()->expr()->countDistinct($value);
+		assertType('string', $result);
+	}
+
+	public function countDistinctNonLiteralString2(EntityManagerInterface $em): void
+	{
+		$value = $this->nonLiteralString('A');
+		$result = $em->createQueryBuilder()->expr()->countDistinct($value, 'B', 'C');
+		assertType('string', $result);
+	}
+
+	// Disabled until Doctrine ORM 3.0.0, as the countDistinct() function definition does not use `countDistinct(...$x)`
+	//   https://github.com/doctrine/orm/pull/9911
+	//   https://github.com/phpstan/phpstan-doctrine/pull/352
+	//
+	// public function countDistinctNonLiteralString3(EntityManagerInterface $em): void
+	// {
+	// 	$value = $this->nonLiteralString('B');
+	// 	$result = $em->createQueryBuilder()->expr()->countDistinct('A', $value, 'C');
+	// 	assertType('string', $result);
+	// }
+	//
+	// public function countDistinctNonLiteralString4(EntityManagerInterface $em): void
+	// {
+	// 	$value = $this->nonLiteralString('C');
+	// 	$result = $em->createQueryBuilder()->expr()->countDistinct('A', 'B', $value);
+	// 	assertType('string', $result);
+	// }
+
 	// Might be a problem, as these do not return a 'literal-string'.
 	// As in, functions to support MOD() and ABS() return stringable value objects (Expr\Func).
 	public function isNullNonLiteralStringExprFunc(EntityManagerInterface $em): void

--- a/tests/Type/Doctrine/data/QueryResult/expressionBuilderGetQueryNoObjectManager.php
+++ b/tests/Type/Doctrine/data/QueryResult/expressionBuilderGetQueryNoObjectManager.php
@@ -67,6 +67,44 @@ class ExpressionBuilderGetQueryNoObjectManager
 		assertType('string', $result);
 	}
 
+	public function countDistinctLiteralString(EntityManagerInterface $em): void
+	{
+		$result = $em->createQueryBuilder()->expr()->countDistinct('A', 'B', 'C');
+		assertType('literal-string', $result);
+	}
+
+	public function countDistinctNonLiteralString1(EntityManagerInterface $em): void
+	{
+		$value = $this->nonLiteralString('A');
+		$result = $em->createQueryBuilder()->expr()->countDistinct($value);
+		assertType('string', $result);
+	}
+
+	public function countDistinctNonLiteralString2(EntityManagerInterface $em): void
+	{
+		$value = $this->nonLiteralString('A');
+		$result = $em->createQueryBuilder()->expr()->countDistinct($value, 'B', 'C');
+		assertType('string', $result);
+	}
+
+	// Disabled until Doctrine ORM 3.0.0, as the countDistinct() function definition does not use `countDistinct(...$x)`
+	//   https://github.com/doctrine/orm/pull/9911
+	//   https://github.com/phpstan/phpstan-doctrine/pull/352
+	//
+	// public function countDistinctNonLiteralString3(EntityManagerInterface $em): void
+	// {
+	// 	$value = $this->nonLiteralString('B');
+	// 	$result = $em->createQueryBuilder()->expr()->countDistinct('A', $value, 'C');
+	// 	assertType('string', $result);
+	// }
+	//
+	// public function countDistinctNonLiteralString4(EntityManagerInterface $em): void
+	// {
+	// 	$value = $this->nonLiteralString('C');
+	// 	$result = $em->createQueryBuilder()->expr()->countDistinct('A', 'B', $value);
+	// 	assertType('string', $result);
+	// }
+
 	// Might be a problem, as these do not return a 'literal-string'.
 	// As in, functions to support MOD() and ABS() return stringable value objects (Expr\Func).
 	public function isNullNonLiteralStringExprFunc(EntityManagerInterface $em): void


### PR DESCRIPTION
Not complete.

The tests that use a non-`literal-string` for parameters 2 and 3, incorrectly return a `literal-string`.

---

These tests should work ([results](https://phpstan.org/r/5b70ac59-4e91-4dd5-ac7d-b63eec30cef8)).

I suspect the original function definition, which implies only 1 parameter is used ([source](https://github.com/doctrine/orm/blob/ab4844b82af9b18cdff20a4d14dc1aeb4ddd08da/lib/Doctrine/ORM/Query/Expr.php#L263)):

    public function countDistinct($x)
    {
        return 'COUNT(DISTINCT ' . implode(', ', func_get_args()) . ')';
    }

Maybe the Stub file should be overriding this? Because I suspect the `@template` only considers the first parameter in this case, even though the Stub tries to correct it ([source](https://github.com/craigfrancis/phpstan-doctrine/blob/issue-294/stubs/ORM/Query/Expr.stub#L39)):

	/**
	 * @template T of string
	 * @param T ...$x
	 * @return (T is literal-string ? literal-string : string)
	 */
	public function countDistinct(...$x) {
	}