### PR TITLE
Fix Repository stubs

### DIFF
--- a/stubs/DocumentRepository.stub
+++ b/stubs/DocumentRepository.stub
@@ -20,21 +20,21 @@ class DocumentRepository implements ObjectRepository
 	public function find($id, $lockMode = null, $lockVersion = null);
 
 	/**
-	 * @phpstan-return TDocumentClass[]
+	 * @phpstan-return array<int, TDocumentClass>
 	 */
 	public function findAll();
 
 	/**
-	 * @phpstan-param mixed[] $criteria
-	 * @phpstan-param string[]|null $sort
+	 * @phpstan-param array<string, mixed> $criteria
+	 * @phpstan-param array<string, string>|null $sort
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $skip
-	 * @phpstan-return TDocumentClass[]
+	 * @phpstan-return array<int, TDocumentClass>
 	 */
 	public function findBy(array $criteria, ?array $sort = null, $limit = null, $skip = null);
 
 	/**
-	 * @phpstan-param mixed[] $criteria The criteria.
+	 * @phpstan-param array<string, mixed> $criteria The criteria.
 	 * @phpstan-return TDocumentClass|null
 	 */
 	public function findOneBy(array $criteria);

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -24,7 +24,7 @@ class EntityRepository implements ObjectRepository
 	public function find($id, $lockMode = null, $lockVersion = null);
 
 	/**
-	 * @phpstan-return TEntityClass[]
+	 * @phpstan-return list<TEntityClass>
 	 */
 	public function findAll();
 
@@ -33,7 +33,7 @@ class EntityRepository implements ObjectRepository
 	 * @phpstan-param array<string, string>|null $orderBy
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $offset
-	 * @phpstan-return TEntityClass[]
+	 * @phpstan-return list<TEntityClass>
 	 */
 	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
 

--- a/stubs/Persistence/ObjectRepository.stub
+++ b/stubs/Persistence/ObjectRepository.stub
@@ -15,7 +15,7 @@ interface ObjectRepository
 	public function find($id);
 
 	/**
-	 * @phpstan-return TEntityClass[]
+	 * @phpstan-return array<int, TEntityClass>
 	 */
 	public function findAll();
 
@@ -24,7 +24,7 @@ interface ObjectRepository
 	 * @phpstan-param array<string, string>|null $orderBy
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $offset
-	 * @phpstan-return TEntityClass[]
+	 * @phpstan-return array<int, TEntityClass>
 	 */
 	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
 

--- a/stubs/bleedingEdge/EntityRepository.stub
+++ b/stubs/bleedingEdge/EntityRepository.stub
@@ -24,7 +24,7 @@ class EntityRepository implements ObjectRepository
 	public function find($id, $lockMode = null, $lockVersion = null);
 
 	/**
-	 * @phpstan-return TEntityClass[]
+	 * @phpstan-return list<TEntityClass>
 	 */
 	public function findAll();
 
@@ -33,7 +33,7 @@ class EntityRepository implements ObjectRepository
 	 * @phpstan-param array<string, string>|null $orderBy
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $offset
-	 * @phpstan-return TEntityClass[]
+	 * @phpstan-return list<TEntityClass>
 	 */
 	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
 


### PR DESCRIPTION
Using `something[]` in docblocks is a bad practice (in fact I'd very much love to have a rule that would disallow it) because then you don't know if the keys are ints or strings. And in many cases when the syntax is used, it is actually a `list<>`.

I changed the types according to those found in Doctrine repositories. I find it a bit odd for ObjectRepository to not return `list<>` but this is how it is currently typed in Doctrine. EntityRepository is typed to return `list<>` as expected.