### PR TITLE
Fix type for enumType in ClassMetaData

### DIFF
--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -45,7 +45,6 @@ use function intval;
 use function is_numeric;
 use function is_object;
 use function is_string;
-use function is_subclass_of;
 use function serialize;
 use function sprintf;
 use function strtolower;
@@ -1300,7 +1299,7 @@ class QueryResultTypeWalker extends SqlWalker
 		$type = $metadata['type'];
 		$enumType = $metadata['enumType'] ?? null;
 
-		if (!is_string($enumType) || !class_exists($enumType) || !is_subclass_of($enumType, BackedEnum::class)) {
+		if (!is_string($enumType) || !class_exists($enumType)) {
 			$enumType = null;
 		}
 

--- a/stubs/ORM/Mapping/ClassMetadataInfo.stub
+++ b/stubs/ORM/Mapping/ClassMetadataInfo.stub
@@ -18,7 +18,7 @@ use ReflectionClass;
  *      notInsertable?: bool,
  *      notUpdatable?: bool,
  *      generated?: int,
- *      enumType?: class-string<BackedEnum>,
+ *      enumType?: class-string<\BackedEnum>,
  *      columnDefinition?: string,
  *      precision?: int,
  *      scale?: int,


### PR DESCRIPTION
Since the ClassMetadataInfo-class is namespaced, the BackedEnum-reference should be prefixed with a back slash. Without it, the type of `enumType` becomes `Doctrine\ORM\Mapping\BackedEnum` which is invalid.

Fixes #391