### PR TITLE
Reduce big int type from string to numeric-string

### DIFF
--- a/src/Type/Doctrine/Descriptors/BigIntType.php
+++ b/src/Type/Doctrine/Descriptors/BigIntType.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type\Doctrine\Descriptors;
 
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -17,7 +18,7 @@ class BigIntType implements DoctrineTypeDescriptor
 
 	public function getWritableToPropertyType(): Type
 	{
-		return new StringType();
+		return TypeCombinator::intersect(new StringType(), new AccessoryNumericStringType());
 	}
 
 	public function getWritableToDatabaseType(): Type

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -349,7 +349,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				]),
 				$this->constantArray([
 					[new ConstantIntegerType(0), new ObjectType(One::class)],
-					[new ConstantStringType('id'), new StringType()],
+					[new ConstantStringType('id'), $this->numericString()],
 					[new ConstantStringType('intColumn'), new IntegerType()],
 				])
 			),
@@ -371,7 +371,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				]),
 				$this->constantArray([
 					[new ConstantIntegerType(0), new ObjectType(Many::class)],
-					[new ConstantStringType('id'), new StringType()],
+					[new ConstantStringType('id'), $this->numericString()],
 					[new ConstantStringType('intColumn'), new IntegerType()],
 				])
 			),
@@ -392,7 +392,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				]),
 				$this->constantArray([
 					[new ConstantStringType('one'), new ObjectType(One::class)],
-					[new ConstantStringType('id'), new StringType()],
+					[new ConstantStringType('id'), $this->numericString()],
 					[new ConstantStringType('intColumn'), new IntegerType()],
 				])
 			),
@@ -502,7 +502,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'just root entity and scalars' => [
 			$this->constantArray([
 				[new ConstantIntegerType(0), new ObjectType(One::class)],
-				[new ConstantStringType('id'), new StringType()],
+				[new ConstantStringType('id'), $this->numericString()],
 			]),
 			'
 				SELECT		o, o.id


### PR DESCRIPTION
When querying a bigInt field, the property is currently considered as a `string`.
I think we can narrow this to `numeric-string` since the internal type is an `int`.