### PR TITLE
#202 Add rule to prevent final constructors in doctrine entities

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -23,7 +23,6 @@ rules:
 	- PHPStan\Rules\Doctrine\ORM\DqlRule
 	- PHPStan\Rules\Doctrine\ORM\RepositoryMethodCallRule
 	- PHPStan\Rules\Doctrine\ORM\EntityNotFinalRule
-	- PHPStan\Rules\Doctrine\ORM\EntityConstructorNotFinalRule
 
 conditionalTags:
 	PHPStan\Rules\Doctrine\ORM\EntityMappingExceptionRule:

--- a/rules.neon
+++ b/rules.neon
@@ -23,9 +23,12 @@ rules:
 	- PHPStan\Rules\Doctrine\ORM\DqlRule
 	- PHPStan\Rules\Doctrine\ORM\RepositoryMethodCallRule
 	- PHPStan\Rules\Doctrine\ORM\EntityNotFinalRule
+	- PHPStan\Rules\Doctrine\ORM\EntityConstructorNotFinalRule
 
 conditionalTags:
 	PHPStan\Rules\Doctrine\ORM\EntityMappingExceptionRule:
+		phpstan.rules.rule: %featureToggles.bleedingEdge%
+	PHPStan\Rules\Doctrine\ORM\EntityConstructorNotFinalRule:
 		phpstan.rules.rule: %featureToggles.bleedingEdge%
 
 services:
@@ -54,3 +57,5 @@ services:
 			bleedingEdge: %featureToggles.bleedingEdge%
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PHPStan\Rules\Doctrine\ORM\EntityConstructorNotFinalRule

--- a/src/Rules/Doctrine/ORM/EntityConstructorNotFinalRule.php
+++ b/src/Rules/Doctrine/ORM/EntityConstructorNotFinalRule.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use function sprintf;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+class EntityConstructorNotFinalRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return ClassMethod::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if ($node->name->name !== '__construct') {
+			return [];
+		}
+
+		if (!$node->isFinal()) {
+			return [];
+		}
+
+		$classReflection = $scope->getClassReflection();
+
+		if ($classReflection === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		return [sprintf(
+			'Constructor of class %s is final which can cause problems with proxies.',
+			$classReflection->getDisplayName()
+		)];
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/EntityConstructorNotFinalRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityConstructorNotFinalRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Doctrine\ORM;
 use Iterator;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
 
 /**
  * @extends RuleTestCase<EntityConstructorNotFinalRule>
@@ -12,9 +13,14 @@ use PHPStan\Testing\RuleTestCase;
 class EntityConstructorNotFinalRuleTest extends RuleTestCase
 {
 
+	/** @var string|null */
+	private $objectManagerLoader;
+
 	protected function getRule(): Rule
 	{
-		return new EntityConstructorNotFinalRule();
+		return new EntityConstructorNotFinalRule(
+			new ObjectMetadataResolver($this->objectManagerLoader)
+		);
 	}
 
 	/**
@@ -23,6 +29,17 @@ class EntityConstructorNotFinalRuleTest extends RuleTestCase
 	 */
 	public function testRule(string $file, array $expectedErrors): void
 	{
+		$this->objectManagerLoader = __DIR__ . '/entity-manager.php';
+		$this->analyse([$file], $expectedErrors);
+	}
+
+	/**
+	 * @dataProvider ruleProvider
+	 * @param list<array{0: string, 1: int, 2?: string}> $expectedErrors
+	 */
+	public function testRuleWithoutObjectManagerLoader(string $file, array $expectedErrors): void
+	{
+		$this->objectManagerLoader = null;
 		$this->analyse([$file], $expectedErrors);
 	}
 
@@ -48,6 +65,11 @@ class EntityConstructorNotFinalRuleTest extends RuleTestCase
 
 		yield 'correct entity' => [
 			__DIR__ . '/data/MyEntity.php',
+			[],
+		];
+
+		yield 'non-entity final constructor' => [
+			__DIR__ . '/data/NonEntityFinalConstructor.php',
 			[],
 		];
 

--- a/tests/Rules/Doctrine/ORM/EntityConstructorNotFinalRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityConstructorNotFinalRuleTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<EntityConstructorNotFinalRule>
+ */
+class EntityConstructorNotFinalRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new EntityConstructorNotFinalRule();
+	}
+
+	/**
+	 * @dataProvider ruleProvider
+	 * @param list<array{0: string, 1: int, 2?: string}> $expectedErrors
+	 */
+	public function testRule(string $file, array $expectedErrors): void
+	{
+		$this->analyse([$file], $expectedErrors);
+	}
+
+	/**
+	 * @return Iterator<mixed[]>
+	 */
+	public function ruleProvider(): Iterator
+	{
+		yield 'entity final constructor' => [
+			__DIR__ . '/data/EntityFinalConstructor.php',
+			[
+				[
+					'Constructor of class PHPStan\Rules\Doctrine\ORM\EntityFinalConstructor is final which can cause problems with proxies.',
+					12,
+				],
+			],
+		];
+
+		yield 'entity non-final constructor' => [
+			__DIR__ . '/data/EntityNonFinalConstructor.php',
+			[],
+		];
+
+		yield 'correct entity' => [
+			__DIR__ . '/data/MyEntity.php',
+			[],
+		];
+
+		yield 'final embeddable' => [
+			__DIR__ . '/data/FinalEmbeddable.php',
+			[],
+		];
+
+		yield 'non final embeddable' => [
+			__DIR__ . '/data/MyEmbeddable.php',
+			[],
+		];
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/data/EntityFinalConstructor.php
+++ b/tests/Rules/Doctrine/ORM/data/EntityFinalConstructor.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class EntityFinalConstructor
+{
+	final public function __construct(string $x)
+	{}
+}

--- a/tests/Rules/Doctrine/ORM/data/EntityNonFinalConstructor.php
+++ b/tests/Rules/Doctrine/ORM/data/EntityNonFinalConstructor.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class EntityNonFinalConstructor
+{
+	public function __construct()
+	{}
+
+	final public function foo()
+	{}
+}

--- a/tests/Rules/Doctrine/ORM/data/NonEntityFinalConstructor.php
+++ b/tests/Rules/Doctrine/ORM/data/NonEntityFinalConstructor.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+class NonEntityFinalConstructor
+{
+	final public function __construct(string $x)
+	{}
+}


### PR DESCRIPTION
This fixes #202.

- Prevent Doctrine entities from containing final constructors
- At the same time, don't forbid non-constructor final methods in Doctrine entities

What do you think about that?