### PR TITLE
Remove AbstractQuery::setParameters stub

### DIFF
--- a/stubs/ORM/AbstractQuery.stub
+++ b/stubs/ORM/AbstractQuery.stub
@@ -10,13 +10,4 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 abstract class AbstractQuery
 {
-
-	/**
-	 * @param ArrayCollection<array-key, mixed>|array<mixed> $parameters
-	 * @return static
-	 */
-	public function setParameters($parameters)
-	{
-
-	}
 }


### PR DESCRIPTION
Original code already has [correct type hints]( https://github.com/doctrine/orm/blob/ba7387fd8c310087b5bc3e176d67671b9739e28c/lib/Doctrine/ORM/AbstractQuery.php#L347) so the stub is redundant.

Ref https://github.com/phpstan/phpstan-doctrine/issues/302#issuecomment-1071116180