### PR TITLE
Improve the type descriptor for SimpleArrayType

### DIFF
--- a/src/Type/Doctrine/Descriptors/SimpleArrayType.php
+++ b/src/Type/Doctrine/Descriptors/SimpleArrayType.php
@@ -2,7 +2,9 @@
 
 namespace PHPStan\Type\Doctrine\Descriptors;
 
+use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -17,12 +19,12 @@ class SimpleArrayType implements DoctrineTypeDescriptor
 
 	public function getWritableToPropertyType(): Type
 	{
-		return new ArrayType(new MixedType(), new MixedType());
+		return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new StringType()));
 	}
 
 	public function getWritableToDatabaseType(): Type
 	{
-		return new ArrayType(new MixedType(), new MixedType());
+		return new ArrayType(new MixedType(), new StringType());
 	}
 
 	public function getDatabaseInternalType(): Type

--- a/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
@@ -159,7 +159,11 @@ class EntityColumnRuleTest extends RuleTestCase
 				156,
 			],
 			[
-				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: property can contain array but database expects array<string>.',
+				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: database can contain array<int, string> but property expects array<int>.',
+				162,
+			],
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: property can contain array<int> but database expects array<string>.',
 				162,
 			],
 		]);
@@ -218,7 +222,11 @@ class EntityColumnRuleTest extends RuleTestCase
 				156,
 			],
 			[
-				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: property can contain array but database expects array<string>.',
+				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: database can contain array<int, string> but property expects array<int>.',
+				162,
+			],
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: property can contain array<int> but database expects array<string>.',
 				162,
 			],
 		]);

--- a/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
@@ -20,6 +20,7 @@ use PHPStan\Type\Doctrine\Descriptors\IntegerType;
 use PHPStan\Type\Doctrine\Descriptors\JsonType;
 use PHPStan\Type\Doctrine\Descriptors\Ramsey\UuidTypeDescriptor;
 use PHPStan\Type\Doctrine\Descriptors\ReflectionDescriptor;
+use PHPStan\Type\Doctrine\Descriptors\SimpleArrayType;
 use PHPStan\Type\Doctrine\Descriptors\StringType;
 use PHPStan\Type\Doctrine\ObjectMetadataResolver;
 use Ramsey\Uuid\Doctrine\UuidType;
@@ -68,6 +69,7 @@ class EntityColumnRuleTest extends RuleTestCase
 				new JsonType(),
 				new IntegerType(),
 				new StringType(),
+				new SimpleArrayType(),
 				new UuidTypeDescriptor(UuidType::class),
 				new ReflectionDescriptor(CarbonImmutableType::class, $this->createBroker()),
 				new ReflectionDescriptor(CarbonType::class, $this->createBroker()),
@@ -156,6 +158,10 @@ class EntityColumnRuleTest extends RuleTestCase
 				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$incompatibleJsonValueObject type mapping mismatch: property can contain PHPStan\Rules\Doctrine\ORM\EmptyObject but database expects array|bool|float|int|JsonSerializable|stdClass|string|null.',
 				156,
 			],
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: property can contain array but database expects array<string>.',
+				162,
+			],
 		]);
 	}
 
@@ -210,6 +216,10 @@ class EntityColumnRuleTest extends RuleTestCase
 			[
 				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$incompatibleJsonValueObject type mapping mismatch: property can contain PHPStan\Rules\Doctrine\ORM\EmptyObject but database expects array|bool|float|int|JsonSerializable|stdClass|string|null.',
 				156,
+			],
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\MyBrokenEntity::$invalidSimpleArray type mapping mismatch: property can contain array but database expects array<string>.',
+				162,
 			],
 		]);
 	}

--- a/tests/Rules/Doctrine/ORM/data/MyBrokenEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/MyBrokenEntity.php
@@ -154,4 +154,16 @@ class MyBrokenEntity extends MyBrokenSuperclass
 	 * @var EmptyObject
 	 */
 	private $incompatibleJsonValueObject;
+
+	/**
+	 * @ORM\Column(type="simple_array")
+	 * @var int[]
+	 */
+	private $invalidSimpleArray;
+
+	/**
+	 * @ORM\Column(type="simple_array")
+	 * @var list<string>
+	 */
+	private $validSimpleArray;
 }

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -132,6 +132,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				$many->stringNullColumn = $stringNullColumnMany;
 				$many->datetimeColumn = new DateTime('2001-01-01 00:00:00');
 				$many->datetimeImmutableColumn = new DateTimeImmutable('2001-01-01 00:00:00');
+				$many->simpleArrayColumn = ['foo'];
 				$many->one = $one;
 				$one->manies->add($many);
 				$em->persist($many);

--- a/tests/Type/Doctrine/data/QueryResult/Entities/Many.php
+++ b/tests/Type/Doctrine/data/QueryResult/Entities/Many.php
@@ -102,6 +102,12 @@ class Many
 	 * @var CompoundPkAssoc|null
 	 */
 	public $compoundPkAssoc;
+
+	/**
+	 * @ORM\Column(type="simple_array")
+	 * @var list<string>
+	 */
+	public $simpleArrayColumn;
 }
 
 /**

--- a/tests/Type/Doctrine/data/QueryResult/createQuery.php
+++ b/tests/Type/Doctrine/data/QueryResult/createQuery.php
@@ -25,6 +25,13 @@ class CreateQuery
 		assertType('Doctrine\ORM\Query<null, array{intColumn: int, stringNullColumn: string|null}>', $query);
 	}
 
+	public function testQueryTypeSimpleArray(EntityManagerInterface $em): void
+	{
+		$query = $em->createQuery('SELECT m.simpleArrayColumn FROM QueryResult\Entities\Many m');
+
+		assertType('Doctrine\ORM\Query<null, array{simpleArrayColumn: list<string>}>', $query);
+	}
+
 	public function testQueryResultTypeIsMixedWhenDQLIsNotKnown(EntityManagerInterface $em, string $dql): void
 	{
 		$query = $em->createQuery($dql);


### PR DESCRIPTION
When converting database values to PHP, this type always produces a `list<string>`