### PR TITLE
Avoid false positive about getArrayResult when selecting objects

### DIFF
--- a/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
@@ -199,9 +199,14 @@ final class QueryResultDynamicReturnTypeExtension implements DynamicMethodReturn
 					return new MixedType();
 				}
 
-				return $objectManager->getMetadataFactory()->hasMetadataFor($type->getClassName())
-					? new ArrayType(new MixedType(), new MixedType())
-					: $traverse($type);
+				if (!$objectManager->getMetadataFactory()->hasMetadataFor($type->getClassName())) {
+					return $traverse($type);
+				}
+
+				// We could return `new ArrayTyp(new MixedType(), new MixedType())`
+				// but the lack of precision in the array keys/values would give false positive
+				// @see https://github.com/phpstan/phpstan-doctrine/pull/412#issuecomment-1497092934
+				return new MixedType();
 			}
 		);
 	}

--- a/tests/Type/Doctrine/data/QueryResult/queryResult.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryResult.php
@@ -155,35 +155,35 @@ class QueryResultTest
 		');
 
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->getResult(AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->getArrayResult()
 		);
 		assertType(
-			'iterable<int, array>',
+			'iterable<int, mixed>',
 			$query->toIterable([], AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->execute(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'array',
+			'mixed',
 			$query->getSingleResult(AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'array|null',
+			'mixed',
 			$query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)
 		);
 


### PR DESCRIPTION
This would be a ok quick-fix for the false positive https://github.com/phpstan/phpstan-doctrine/pull/412#issuecomment-1497092934

It's basically a revert of the previous PR but just in the case of object provided in the `getArrayResult`.

I'm working on a long-term fix/improvement with https://github.com/phpstan/phpstan-doctrine/pull/443 but it's not easy for multi-select queries.