### PR TITLE
Use benevolent union for scalar in queries

### DIFF
--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -847,6 +847,8 @@ class QueryResultTypeWalker extends SqlWalker
 				// Here we assume that the value may or may not be casted to
 				// string by the driver.
 				$casted = false;
+				$originalType = $type;
+
 				$type = TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$casted): Type {
 					if ($type instanceof UnionType || $type instanceof IntersectionType) {
 						return $traverse($type);
@@ -864,7 +866,7 @@ class QueryResultTypeWalker extends SqlWalker
 
 				// Since we made supposition about possibly casted values,
 				// we can only provide a benevolent union.
-				if ($casted && $type instanceof UnionType) {
+				if ($casted && $type instanceof UnionType && !$originalType->equals($type)) {
 					$type = TypeUtils::toBenevolentUnion($type);
 				}
 			}

--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -106,6 +106,9 @@ class QueryResultTypeWalker extends SqlWalker
 	/** @var bool */
 	private $hasGroupByClause;
 
+	/** @var bool */
+	private $hasCondition;
+
 	/**
 	 * @param Query<mixed> $query
 	 */
@@ -134,6 +137,7 @@ class QueryResultTypeWalker extends SqlWalker
 		$this->nullableQueryComponents = [];
 		$this->hasAggregateFunction = false;
 		$this->hasGroupByClause = false;
+		$this->hasCondition = false;
 
 		// The object is instantiated by Doctrine\ORM\Query\Parser, so receiving
 		// dependencies through the constructor is not an option. Instead, we
@@ -589,6 +593,8 @@ class QueryResultTypeWalker extends SqlWalker
 	 */
 	public function walkHavingClause($havingClause)
 	{
+		$this->hasCondition = true;
+
 		return $this->marshalType(new MixedType());
 	}
 
@@ -993,6 +999,8 @@ class QueryResultTypeWalker extends SqlWalker
 	 */
 	public function walkWhereClause($whereClause)
 	{
+		$this->hasCondition = true;
+
 		return $this->marshalType(new MixedType());
 	}
 
@@ -1280,7 +1288,10 @@ class QueryResultTypeWalker extends SqlWalker
 	 */
 	private function addScalar($alias, Type $type): void
 	{
-		if ($type instanceof UnionType) {
+		// Since we don't check the condition inside the WHERE or HAVING
+		// conditions, we cannot be sure all the union types are correct.
+		// For exemple, a condition `WHERE foo.bar IS NOT NULL` could be added.
+		if ($this->hasCondition && $type instanceof UnionType) {
 			$type = TypeUtils::toBenevolentUnion($type);
 		}
 

--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -794,7 +794,7 @@ class QueryResultTypeWalker extends SqlWalker
 
 			$type = $this->resolveDoctrineType($typeName, $enumType, $nullable);
 
-			$this->typeBuilder->addScalar($resultAlias, $type);
+			$this->addScalar($resultAlias, $type);
 
 			return '';
 		}
@@ -854,7 +854,7 @@ class QueryResultTypeWalker extends SqlWalker
 				});
 			}
 
-			$this->typeBuilder->addScalar($resultAlias, $type);
+			$this->addScalar($resultAlias, $type);
 
 			return '';
 		}
@@ -1273,6 +1273,18 @@ class QueryResultTypeWalker extends SqlWalker
 	public function walkResultVariable($resultVariable)
 	{
 		return $this->marshalType(new MixedType());
+	}
+
+	/**
+	 * @param array-key $alias
+	 */
+	private function addScalar($alias, Type $type): void
+	{
+		if ($type instanceof UnionType) {
+			$type = TypeUtils::toBenevolentUnion($type);
+		}
+
+		$this->typeBuilder->addScalar($alias, $type);
 	}
 
 	private function unmarshalType(string $marshalledType): Type

--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -107,7 +107,7 @@ class QueryResultTypeWalker extends SqlWalker
 	private $hasGroupByClause;
 
 	/** @var bool */
-	private $hasCondition;
+	private $hasWhereClause;
 
 	/**
 	 * @param Query<mixed> $query
@@ -137,7 +137,7 @@ class QueryResultTypeWalker extends SqlWalker
 		$this->nullableQueryComponents = [];
 		$this->hasAggregateFunction = false;
 		$this->hasGroupByClause = false;
-		$this->hasCondition = false;
+		$this->hasWhereClause = false;
 
 		// The object is instantiated by Doctrine\ORM\Query\Parser, so receiving
 		// dependencies through the constructor is not an option. Instead, we
@@ -180,6 +180,7 @@ class QueryResultTypeWalker extends SqlWalker
 		$this->typeBuilder->setSelectQuery();
 		$this->hasAggregateFunction = $this->hasAggregateFunction($AST);
 		$this->hasGroupByClause = $AST->groupByClause !== null;
+		$this->hasWhereClause = $AST->whereClause !== null;
 
 		$this->walkFromClause($AST->fromClause);
 
@@ -593,8 +594,6 @@ class QueryResultTypeWalker extends SqlWalker
 	 */
 	public function walkHavingClause($havingClause)
 	{
-		$this->hasCondition = true;
-
 		return $this->marshalType(new MixedType());
 	}
 
@@ -1010,8 +1009,6 @@ class QueryResultTypeWalker extends SqlWalker
 	 */
 	public function walkWhereClause($whereClause)
 	{
-		$this->hasCondition = true;
-
 		return $this->marshalType(new MixedType());
 	}
 
@@ -1299,10 +1296,10 @@ class QueryResultTypeWalker extends SqlWalker
 	 */
 	private function addScalar($alias, Type $type): void
 	{
-		// Since we don't check the condition inside the WHERE or HAVING
+		// Since we don't check the condition inside the WHERE
 		// conditions, we cannot be sure all the union types are correct.
 		// For exemple, a condition `WHERE foo.bar IS NOT NULL` could be added.
-		if ($this->hasCondition && $type instanceof UnionType) {
+		if ($this->hasWhereClause && $type instanceof UnionType) {
 			$type = TypeUtils::toBenevolentUnion($type);
 		}
 

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -28,6 +29,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use QueryResult\Entities\Embedded;
@@ -543,12 +545,12 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					],
 					[
 						new ConstantIntegerType(2),
-						TypeCombinator::union(
+						TypeUtils::toBenevolentUnion(TypeCombinator::union(
 							new ConstantIntegerType(1),
 							new ConstantIntegerType(2),
 							new ConstantStringType('1'),
 							new ConstantStringType('2')
-						),
+						)),
 					],
 					[
 						new ConstantIntegerType(3),
@@ -595,7 +597,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantIntegerType(2),
@@ -609,7 +611,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(4),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantIntegerType(5),
@@ -619,7 +621,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(6),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantIntegerType(7),
@@ -645,7 +647,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantStringType('max'),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantStringType('arithmetic'),
@@ -677,10 +679,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantStringType('1'),
 						new ConstantIntegerType(1)
-					),
+					)),
 				],
 				[new ConstantIntegerType(2), new ConstantStringType('hello')],
 			]),
@@ -694,11 +696,11 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(1),
 						new ConstantStringType('1'),
 						new NullType()
-					),
+					)),
 				],
 			]),
 			'
@@ -711,10 +713,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new StringType(),
 						new IntegerType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(2),
@@ -740,10 +742,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					),
+					)),
 				],
 			]),
 			'
@@ -760,10 +762,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					),
+					)),
 				],
 			]),
 			'
@@ -780,12 +782,12 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantIntegerType(1),
 						new ConstantStringType('0'),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 			]),
 			'
@@ -801,12 +803,12 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantIntegerType(1),
 						new ConstantStringType('0'),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 			]),
 			'
@@ -822,31 +824,31 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(1),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(2),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantStringType('0')
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(3),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(1),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(4),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantStringType('0')
-					),
+					)),
 				],
 			]),
 			'
@@ -1018,10 +1020,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					],
 					[
 						new ConstantIntegerType(2),
-						TypeCombinator::union(
+						TypeUtils::toBenevolentUnion(TypeCombinator::union(
 							new ConstantIntegerType(1),
 							new ConstantStringType('1')
-						),
+						)),
 					],
 					[
 						new ConstantStringType('intColumn'),
@@ -1065,7 +1067,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'new arguments affect scalar counter' => [
 			$this->constantArray([
-				[new ConstantIntegerType(5), TypeCombinator::addNull($this->intStringified())],
+				[new ConstantIntegerType(5), $this->intStringified(true)],
 				[new ConstantIntegerType(0), new ObjectType(ManyId::class)],
 				[new ConstantIntegerType(1), new ObjectType(OneId::class)],
 			]),
@@ -1082,7 +1084,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				[new ConstantStringType('intColumn'), new IntegerType()],
 				[new ConstantIntegerType(1), $this->intStringified()],
 				[new ConstantIntegerType(2), $this->intStringified()],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->intStringified())],
+				[new ConstantIntegerType(3), $this->intStringified(true)],
 				[new ConstantIntegerType(4), $this->intStringified()],
 				[new ConstantIntegerType(5), $this->intStringified()],
 				[new ConstantIntegerType(6), $this->numericStringified()],
@@ -1104,9 +1106,9 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'abs function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->unumericStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->unumericStringified())],
+				[new ConstantIntegerType(2), $this->unumericStringified(true)],
 				[new ConstantIntegerType(3), $this->unumericStringified()],
-				[new ConstantIntegerType(4), TypeCombinator::union($this->unumericStringified())],
+				[new ConstantIntegerType(4), $this->unumericStringified()],
 			]),
 			'
 				SELECT		ABS(m.intColumn),
@@ -1120,7 +1122,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'bit_and function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->uintStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(2), $this->uintStringified(true)],
 				[new ConstantIntegerType(3), $this->uintStringified()],
 			]),
 			'
@@ -1134,7 +1136,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'bit_or function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->uintStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(2), $this->uintStringified(true)],
 				[new ConstantIntegerType(3), $this->uintStringified()],
 			]),
 			'
@@ -1210,8 +1212,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'date_diff function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->numericStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->numericStringified())],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->numericStringified())],
+				[new ConstantIntegerType(2), $this->numericStringified(true)],
+				[new ConstantIntegerType(3), $this->numericStringified(true)],
 				[new ConstantIntegerType(4), $this->numericStringified()],
 			]),
 			'
@@ -1253,11 +1255,9 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(2),
-					TypeCombinator::addNull(
-						$this->hasTypedExpressions()
-						? $this->uint()
-						: $this->uintStringified()
-					),
+					$this->hasTypedExpressions()
+					? $this->uint(true)
+					: $this->uintStringified(true)
 				],
 				[
 					new ConstantIntegerType(3),
@@ -1278,8 +1278,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			yield 'locate function' => [
 				$this->constantArray([
 					[new ConstantIntegerType(1), $this->uintStringified()],
-					[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
-					[new ConstantIntegerType(3), TypeCombinator::addNull($this->uintStringified())],
+					[new ConstantIntegerType(2), $this->uintStringified(true)],
+					[new ConstantIntegerType(3), $this->uintStringified(true)],
 					[new ConstantIntegerType(4), $this->uintStringified()],
 				]),
 				'
@@ -1321,8 +1321,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'mod function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->uintStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(2), $this->uintStringified(true)],
+				[new ConstantIntegerType(3), $this->uintStringified(true)],
 				[new ConstantIntegerType(4), $this->uintStringified()],
 			]),
 			'
@@ -1336,7 +1336,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'mod function error' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(1), $this->uintStringified(true)],
 			]),
 			'
 				SELECT		MOD(10, NULLIF(m.intColumn, m.intColumn))
@@ -1395,15 +1395,15 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'identity function' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
-				[new ConstantIntegerType(2), $this->numericStringOrInt()],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
+				[new ConstantIntegerType(2), $this->intStringified()],
+				[new ConstantIntegerType(3), $this->intStringified(true)],
 				[new ConstantIntegerType(4), TypeCombinator::addNull(new StringType())],
 				[new ConstantIntegerType(5), TypeCombinator::addNull(new StringType())],
-				[new ConstantIntegerType(6), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(6), $this->intStringified(true)],
 				[new ConstantIntegerType(7), TypeCombinator::addNull(new MixedType())],
-				[new ConstantIntegerType(8), TypeCombinator::addNull($this->numericStringOrInt())],
-				[new ConstantIntegerType(9), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(8), $this->intStringified(true)],
+				[new ConstantIntegerType(9), $this->intStringified(true)],
 			]),
 			'
 				SELECT		IDENTITY(m.oneNull),
@@ -1422,7 +1422,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select nullable association' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
 			]),
 			'
 				SELECT		DISTINCT(m.oneNull)
@@ -1432,7 +1432,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select non null association' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), $this->numericStringOrInt()],
+				[new ConstantIntegerType(1), $this->intStringified()],
 			]),
 			'
 				SELECT		DISTINCT(m.one)
@@ -1442,7 +1442,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select default nullability association' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
 			]),
 			'
 				SELECT		DISTINCT(m.oneDefaultNullability)
@@ -1452,7 +1452,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select non null association in aggregated query' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
 				[
 					new ConstantIntegerType(2),
 					$this->hasTypedExpressions()
@@ -1522,17 +1522,6 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		return $builder->getArray();
 	}
 
-	private function numericStringOrInt(): Type
-	{
-		return new UnionType([
-			new IntegerType(),
-			new IntersectionType([
-				new StringType(),
-				new AccessoryNumericStringType(),
-			]),
-		]);
-	}
-
 	private function numericString(): Type
 	{
 		return new IntersectionType([
@@ -1541,42 +1530,67 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		]);
 	}
 
-	private function uint(): Type
+	private function uint(bool $nullable = false): Type
 	{
-		return IntegerRangeType::fromInterval(0, null);
+		$type = IntegerRangeType::fromInterval(0, null);
+		if ($nullable) {
+			TypeCombinator::addNull($type);
+		}
+
+		return $type;
 	}
 
-	private function intStringified(): Type
+	private function intStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			new IntegerType(),
-			$this->numericString()
-		);
+			$this->numericString(),
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
-	private function uintStringified(): Type
+	private function uintStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			$this->uint(),
-			$this->numericString()
-		);
+			$this->numericString(),
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
 
-	private function numericStringified(): Type
+	private function numericStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			new FloatType(),
 			new IntegerType(),
-			$this->numericString()
-		);
+			$this->numericString(),
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
 
-	private function unumericStringified(): Type
+	private function unumericStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			new FloatType(),
 			IntegerRangeType::fromInterval(0, null),
 			$this->numericString()
-		);
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
 
 	private function hasTypedExpressions(): bool

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -13,7 +13,6 @@ use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
-use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -30,7 +29,6 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use QueryResult\Entities\Embedded;
 use QueryResult\Entities\JoinedChild;
@@ -1257,7 +1255,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					new ConstantIntegerType(2),
 					$this->hasTypedExpressions()
 					? $this->uint(true)
-					: $this->uintStringified(true)
+					: $this->uintStringified(true),
 				],
 				[
 					new ConstantIntegerType(3),
@@ -1584,7 +1582,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		$types = [
 			new FloatType(),
 			IntegerRangeType::fromInterval(0, null),
-			$this->numericString()
+			$this->numericString(),
 		];
 		if ($nullable) {
 			$types[] = new NullType();

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -441,6 +441,25 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			',
 		];
 
+		yield 'scalar with where condition' => [
+			$this->constantArray([
+				[new ConstantStringType('intColumn'), new IntegerType()],
+				[new ConstantStringType('stringColumn'), new StringType()],
+				[
+					new ConstantStringType('stringNullColumn'),
+					TypeUtils::toBenevolentUnion(TypeCombinator::addNull(new StringType()))
+				],
+				[new ConstantStringType('datetimeColumn'), new ObjectType(DateTime::class)],
+				[new ConstantStringType('datetimeImmutableColumn'), new ObjectType(DateTimeImmutable::class)],
+			]),
+			'
+				SELECT		m.intColumn, m.stringColumn, m.stringNullColumn,
+							m.datetimeColumn, m.datetimeImmutableColumn
+				FROM		QueryResult\Entities\Many m
+				WHERE       m.stringNullColumn IS NOT NULL
+			',
+		];
+
 		yield 'scalar with alias' => [
 			$this->constantArray([
 				[new ConstantStringType('i'), new IntegerType()],

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -447,7 +447,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				[new ConstantStringType('stringColumn'), new StringType()],
 				[
 					new ConstantStringType('stringNullColumn'),
-					TypeUtils::toBenevolentUnion(TypeCombinator::addNull(new StringType()))
+					TypeUtils::toBenevolentUnion(TypeCombinator::addNull(new StringType())),
 				],
 				[new ConstantStringType('datetimeColumn'), new ObjectType(DateTime::class)],
 				[new ConstantStringType('datetimeImmutableColumn'), new ObjectType(DateTimeImmutable::class)],

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -713,10 +713,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeUtils::toBenevolentUnion(TypeCombinator::union(
+					TypeCombinator::union(
 						new StringType(),
 						new IntegerType()
-					)),
+					),
 				],
 				[
 					new ConstantIntegerType(2),
@@ -742,10 +742,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeUtils::toBenevolentUnion(TypeCombinator::union(
+					TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					)),
+					),
 				],
 			]),
 			'
@@ -762,10 +762,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeUtils::toBenevolentUnion(TypeCombinator::union(
+					TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					)),
+					),
 				],
 			]),
 			'

--- a/tests/Type/Doctrine/data/QueryResult/queryResult.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryResult.php
@@ -383,31 +383,31 @@ class QueryResultTest
 		');
 
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->getResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->getSingleScalarResult()
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->execute(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->getSingleResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string|null',
+			'(int<0, max>|numeric-string|null)',
 			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 	}


### PR DESCRIPTION
This PR could be an idea of solution for https://github.com/phpstan/phpstan-doctrine/pull/446

I assume that before https://github.com/phpstan/phpstan-doctrine/pull/412, the resultType of Query were less used a lot so we didn't have a lot of feedback about the type resolution. But I tried to reproduce your "bug", and even the merge of my PR
```
$result = $this->entityManager->createQueryBuilder()
			->select('DISTINCT IDENTITY(oi.product) AS id')
			->from(OrderItem::class, 'oi')
			->join('oi.product', 'p')
			->getQuery()
			->getResult();
```
were reporting `list<array{id: int|numeric-string|null}>`. I just give the same result with `getArrayResult` now.

For Identity, I found some specific solution to improve the return type,
but still, I anticipate a lot of similar issue with results like
```
$result = $this->entityManager->createQueryBuilder()
			->select('p.id AS id')
			->from(OrderItem::class, 'oi')
			->leftJoin('oi.product', 'p')
			->where('p.id IS NOT NULL')
			->getQuery()
			->getArrayResult();
```
which is reported as `list<array{id: int|null}>` when we would expect `list<array{id: int}>`. Notice that in the same way, before https://github.com/phpstan/phpstan-doctrine/pull/412, the query was already returning `list<array{id: int|null}>` for `getResult` calls.

Since we currently cannot be sure that all those `|null` are true because, for example, we don't check the `WHERE` condition (and this would be complex). I think the best solution so far would be to use BenevolentUnion for this instead of default unions.

Before fixing the tests I'd like your opinion on such change.