### PR TITLE
Prevent case mismatch between MySQLPlatform and MySqlPlatform

### DIFF
--- a/src/Doctrine/Mapping/ClassMetadataFactory.php
+++ b/src/Doctrine/Mapping/ClassMetadataFactory.php
@@ -2,16 +2,18 @@
 
 namespace PHPStan\Doctrine\Mapping;
 
+use Composer\InstalledVersions;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\DocParser;
 use Doctrine\Common\EventManager;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use ReflectionClass;
 use function class_exists;
 use function count;
+use function version_compare;
 use const PHP_VERSION_ID;
 
 class ClassMetadataFactory extends \Doctrine\ORM\Mapping\ClassMetadataFactory
@@ -43,10 +45,12 @@ class ClassMetadataFactory extends \Doctrine\ORM\Mapping\ClassMetadataFactory
 		$targetPlatformProperty = $parentReflection->getProperty('targetPlatform');
 		$targetPlatformProperty->setAccessible(true);
 
-		if (class_exists(MySqlPlatform::class)) {
-			$platform = new MySqlPlatform();
+		$version = InstalledVersions::getVersion('doctrine/dbal');
+		$hasDbal3 = $version !== null && version_compare($version, '3', '>=');
+		if ($hasDbal3) {
+			$platform = new MySQLPlatform();
 		} else {
-			$platform = new \Doctrine\DBAL\Platforms\MySQLPlatform();
+			$platform = new \Doctrine\DBAL\Platforms\MySqlPlatform();
 		}
 
 		$targetPlatformProperty->setValue($this, $platform);


### PR DESCRIPTION
In conjunction with `symfony/debug` when the debug mod is enabled, the platform existence check from dbal v2 `MySqlPlatform` generates a lot of errors in output.

Who generated errors:

- method [DebugClassLoader::checkClass#L221](https://github.com/symfony/debug/blob/1a692492190773c5310bc7877cb590c04c2f05be/DebugClassLoader.php#L221) throw exceptions on class case mismatch. 

I propose that the dbal version should be checked instead class_exists.