### PR TITLE
Add missing throws in stubs

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -36,6 +36,7 @@ parameters:
 		- stubs/Collections/ReadableCollection.stub
 		- stubs/Collections/Selectable.stub
 		- stubs/ORM/AbstractQuery.stub
+		- stubs/ORM/Exception/ORMException.stub
 		- stubs/ORM/Id/AbstractIdGenerator.stub
 		- stubs/ORM/Mapping/ClassMetadata.stub
 		- stubs/ORM/Mapping/ClassMetadataInfo.stub

--- a/stubs/EntityManager.stub
+++ b/stubs/EntityManager.stub
@@ -2,6 +2,8 @@
 
 namespace Doctrine\ORM;
 
+use Doctrine\ORM\Exception\ORMException;
+
 class EntityManager implements EntityManagerInterface
 {
 
@@ -35,6 +37,8 @@ class EntityManager implements EntityManagerInterface
 	 * @phpstan-param class-string<T> $entityName
 	 * @phpstan-param mixed $id
 	 * @phpstan-return T|null
+	 *
+	 * @throws ORMException
 	 */
 	public function getReference($entityName, $id);
 

--- a/stubs/EntityManagerDecorator.stub
+++ b/stubs/EntityManagerDecorator.stub
@@ -4,6 +4,7 @@ namespace Doctrine\ORM\Decorator;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Exception\ORMException;
 
 class EntityManagerDecorator implements EntityManagerInterface
 {
@@ -37,6 +38,8 @@ class EntityManagerDecorator implements EntityManagerInterface
 	 * @phpstan-param class-string<T> $entityName
 	 * @phpstan-param mixed $id
 	 * @phpstan-return T|null
+	 *
+	 * @throws ORMException
 	 */
 	public function getReference($entityName, $id);
 

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -4,6 +4,7 @@ namespace Doctrine\ORM;
 
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
+use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 interface EntityManagerInterface extends ObjectManager
@@ -36,6 +37,8 @@ interface EntityManagerInterface extends ObjectManager
 	 * @phpstan-param class-string<T> $entityName
 	 * @phpstan-param mixed $id
 	 * @phpstan-return T|null
+     *
+     * @throws ORMException
 	 */
 	public function getReference($entityName, $id);
 

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -37,8 +37,8 @@ interface EntityManagerInterface extends ObjectManager
 	 * @phpstan-param class-string<T> $entityName
 	 * @phpstan-param mixed $id
 	 * @phpstan-return T|null
-     *
-     * @throws ORMException
+	 *
+	 * @throws ORMException
 	 */
 	public function getReference($entityName, $id);
 

--- a/stubs/ORM/Exception/ORMException.stub
+++ b/stubs/ORM/Exception/ORMException.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\ORM\Exception;
+
+use Doctrine\ORM\ORMException as BaseORMException;
+
+class ORMException extends BaseORMException
+{
+
+}


### PR DESCRIPTION
Hi @ondrejmirtes,

EntityManagerInterface::getReference throws an ORMException
https://github.com/doctrine/orm/blob/4aadba65cefd4efc89e5946c8b0304656c269a4a/lib/Doctrine/ORM/EntityManagerInterface.php#L182

But this is missing in the stub, so PHPStan reports
```
Foo has Doctrine\ORM\Exception\ORMException in PHPDoc @throws tag but it's not thrown.
```