### PR TITLE
Add AbstractQuery::getSingleScalarResult to stub

### DIFF
--- a/stubs/ORM/AbstractQuery.stub
+++ b/stubs/ORM/AbstractQuery.stub
@@ -19,4 +19,10 @@ abstract class AbstractQuery
 	{
 
 	}
+
+	/**
+	* @return bool|float|int|string|null
+	*/
+	public function getSingleScalarResult();
+
 }

--- a/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-9.json
+++ b/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-9.json
@@ -1,7 +1,0 @@
-[
-    {
-        "message": "Cannot cast mixed to int.",
-        "line": 241,
-        "ignorable": true
-    }
-]


### PR DESCRIPTION
`AbstractQuery::getSingleScalarResult()` had its phpDoc narrowed from mixed in latest 2.16 version.

However, this phpDoc is missing return null, as the method can return it https://github.com/doctrine/orm/pull/10870