### PR TITLE
Add throws annotation about NoResultException on getSingleScalarResult

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -41,6 +41,7 @@ parameters:
 		- stubs/ORM/Mapping/ClassMetadata.stub
 		- stubs/ORM/Mapping/ClassMetadataInfo.stub
 		- stubs/ORM/NonUniqueResultException.stub
+		- stubs/ORM/NoResultException.stub
 		- stubs/ORM/ORMException.stub
 		- stubs/ORM/UnexpectedResultException.stub
 		- stubs/ORM/Query/Expr.stub

--- a/stubs/ORM/AbstractQuery.stub
+++ b/stubs/ORM/AbstractQuery.stub
@@ -24,6 +24,7 @@ abstract class AbstractQuery
 	/**
 	* @return bool|float|int|string|null
 	*
+	* @throws NoResultException
 	* @throws NonUniqueResultException
 	*/
 	public function getSingleScalarResult();

--- a/stubs/ORM/NoResultException.stub
+++ b/stubs/ORM/NoResultException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Doctrine\ORM;
+
+class NoResultException extends UnexpectedResultException
+{
+}


### PR DESCRIPTION
Hi @ondrejmirtes,

Similar to the doctrine/orm fix: https://github.com/doctrine/orm/pull/10907