### PR TITLE
Allow doctrine/lexer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"doctrine/collections": "^1.6",
 		"doctrine/common": "^2.7 || ^3.0",
 		"doctrine/dbal": "^2.13.8 || ^3.3.3",
-		"doctrine/lexer": "^1.2.1",
+		"doctrine/lexer": "^1.2.1 || ^2",
 		"doctrine/mongodb-odm": "^1.3 || ^2.1",
 		"doctrine/orm": "^2.11.0",
 		"doctrine/persistence": "^1.3.8 || ^2.2.1",


### PR DESCRIPTION
Locking to v1 makes it impossible to upgrade certain libraries (e.g. jms/serializer)