### PR TITLE
Handle AnnotationException in Gedmo\PropertiesExtension

### DIFF
--- a/src/Rules/Gedmo/PropertiesExtension.php
+++ b/src/Rules/Gedmo/PropertiesExtension.php
@@ -93,7 +93,7 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 
 		try {
 			$annotations = $this->annotationReader->getPropertyAnnotations($propertyReflection);
-		} catch (AnnotationException) {
+		} catch (AnnotationException $e) {
 			// Suppress the "The annotation X was never imported." exception in case the `objectManagerLoader` is not configured
 			return false;
 		}

--- a/src/Rules/Gedmo/PropertiesExtension.php
+++ b/src/Rules/Gedmo/PropertiesExtension.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Gedmo;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Gedmo\Mapping\Annotation as Gedmo;
 use PHPStan\Reflection\PropertyReflection;

--- a/src/Rules/Gedmo/PropertiesExtension.php
+++ b/src/Rules/Gedmo/PropertiesExtension.php
@@ -90,7 +90,13 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 			return false;
 		}
 
-		$annotations = $this->annotationReader->getPropertyAnnotations($propertyReflection);
+		try {
+			$annotations = $this->annotationReader->getPropertyAnnotations($propertyReflection);
+		} catch (AnnotationException) {
+			// Suppress the "The annotation X was never imported." exception in case the `objectManagerLoader` is not configured
+			return false;
+		}
+
 		foreach ($annotations as $annotation) {
 			if (in_array(get_class($annotation), $classList, true)) {
 				return true;


### PR DESCRIPTION
Suppresses the "The annotation X was never imported." exceptions  in case the `objectManagerLoader` is not configured.

closes #480 