### PR TITLE
Add throws annotation on `EntityManagerInterface::flush`

### DIFF
--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -60,19 +60,20 @@ interface EntityManagerInterface extends ObjectManager
 	 */
 	public function copy($entity, $deep = false);
 
-    /**
-     * @return void
-     *
-     * @throws ORMException
-     * @throws \Doctrine\DBAL\Exception\UniqueConstraintViolationException
-     */
-    public function flush();
+	/**
+	 * @return void
+	 *
+	 * @throws ORMException
+	 * @throws \Doctrine\DBAL\Exception\UniqueConstraintViolationException
+	 */
+	public function flush();
 
-  /**
-   * @template T of object
-   * @phpstan-param class-string<T> $className
-   *
-   * @phpstan-return ClassMetadata<T>
-   */
-  public function getClassMetadata($className);
+	/**
+	 * @template T of object
+	 * @phpstan-param class-string<T> $className
+	 *
+	 * @phpstan-return ClassMetadata<T>
+	 */
+	public function getClassMetadata($className);
+
 }

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -60,6 +60,14 @@ interface EntityManagerInterface extends ObjectManager
 	 */
 	public function copy($entity, $deep = false);
 
+    /**
+     * @return void
+     *
+     * @throws ORMException
+     * @throws \Doctrine\DBAL\Exception\UniqueConstraintViolationException
+     */
+    public function flush();
+
   /**
    * @template T of object
    * @phpstan-param class-string<T> $className

--- a/tests/Rules/Exceptions/data/unthrown-exception.php
+++ b/tests/Rules/Exceptions/data/unthrown-exception.php
@@ -8,10 +8,18 @@ class FooFacade
 	/** @var \Doctrine\ORM\EntityManager */
 	private $entityManager;
 
+	/** @var \Doctrine\ORM\EntityManagerInterface */
+	private $entityManagerInterface;
+
 	public function doFoo(): void
 	{
 		try {
 			$this->entityManager->flush();
+		} catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
+			// pass
+		}
+		try {
+			$this->entityManagerInterface->flush();
 		} catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
 			// pass
 		}


### PR DESCRIPTION
This is the same than https://github.com/phpstan/phpstan-doctrine/pull/313 but on the EntityManagerInterface in order to avoid the deadcatch with
```
try {
    $this->entityManagerInterface->flush();
} catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
    // pass
}
```
or avoid `but it's not thrown.` phpstan error.

Injecting the interface rather than `EntityManager` is a really common thing when working with Symfony/doctrine (thanks to autowire/autoconfigure) so the `@throws` annotation will be more useful on the interface.