### PR TITLE
Allow class string in from and join

### DIFF
--- a/stubs/bleedingEdge/ORM/QueryBuilder.stub
+++ b/stubs/bleedingEdge/ORM/QueryBuilder.stub
@@ -58,9 +58,9 @@ class QueryBuilder
 	}
 
 	/**
-	 * @param literal-string      $from
-	 * @param literal-string      $alias
-	 * @param literal-string|null $indexBy
+	 * @param literal-string|class-string $from
+	 * @param literal-string              $alias
+	 * @param literal-string|null         $indexBy
 	 *
 	 * @return $this
 	 */
@@ -70,7 +70,7 @@ class QueryBuilder
 	}
 
 	/**
-	 * @param literal-string                                     $join
+	 * @param literal-string|class-string                        $join
 	 * @param literal-string                                     $alias
 	 * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
 	 * @param literal-string|Expr\Comparison|Expr\Composite|Expr\Func|null $condition
@@ -84,7 +84,7 @@ class QueryBuilder
 	}
 
 	/**
-	 * @param literal-string                                     $join
+	 * @param literal-string|class-string                        $join
 	 * @param literal-string                                     $alias
 	 * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
 	 * @param literal-string|Expr\Comparison|Expr\Composite|Expr\Func|null $condition
@@ -98,7 +98,7 @@ class QueryBuilder
 	}
 
 	/**
-	 * @param literal-string                                     $join
+	 * @param literal-string|class-string                        $join
 	 * @param literal-string                                     $alias
 	 * @param Expr\Join::ON|Expr\Join::WITH|null                 $conditionType
 	 * @param literal-string|Expr\Comparison|Expr\Composite|Expr\Func|null $condition


### PR DESCRIPTION
Doctrine write the following code
```
    /**
     * @psalm-var class-string<T>
     */
    protected $_entityName;

   /**
     * @param string      $alias
     * @param string|null $indexBy The index for the from.
     *
     * @return QueryBuilder
     */
    public function createQueryBuilder($alias, $indexBy = null)
    {
        return $this->_em->createQueryBuilder()
            ->select($alias)
            ->from($this->_entityName, $alias, $indexBy);
    }
```
So they are passing a `class-string<T of object>` to the first from argument.

When doing the same, we get an error
```
Parameter #1 $from of method Doctrine\ORM\QueryBuilder::from() expects literal-string, class-string<T of object> given.
```
I think allowing `class-string|literal-string` doesn't introduce a security issue since no "variable" classname can inject sql.

In the same way `join` methods, can be used in two ways
```
->join('project.organization', ....)
->join(Organization::class, ...)
```
here again, a "variable" classname shouldn't introduce security issues so `class-string|literal-string` should be allowed in order to write
```
->join($someClassName, ...)
```

I didn't work on literal for a long time since https://github.com/phpstan/phpstan-doctrine/pull/327 so I'd be interested in your opinion on this change @craigfrancis.