### PR TITLE
QueryBuilderDqlRule: check also other methods if enabled

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -35,6 +35,7 @@ services:
 		class: PHPStan\Rules\Doctrine\ORM\QueryBuilderDqlRule
 		arguments:
 			reportDynamicQueryBuilders: %doctrine.reportDynamicQueryBuilders%
+			searchOtherMethodsForQueryBuilderBeginning: %doctrine.searchOtherMethodsForQueryBuilderBeginning%
 		tags:
 			- phpstan.rules.rule
 	-

--- a/tests/Rules/Doctrine/ORM/QueryBuilderDqlRuleSlowTest.php
+++ b/tests/Rules/Doctrine/ORM/QueryBuilderDqlRuleSlowTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Doctrine\ORM;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+use PHPStan\Type\Doctrine\QueryBuilder\OtherMethodQueryBuilderParser;
 
 /**
  * @extends RuleTestCase<QueryBuilderDqlRule>
@@ -14,7 +15,12 @@ class QueryBuilderDqlRuleSlowTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new QueryBuilderDqlRule(new ObjectMetadataResolver(__DIR__ . '/entity-manager.php'), true);
+		return new QueryBuilderDqlRule(
+			new ObjectMetadataResolver(__DIR__ . '/entity-manager.php'),
+			self::getContainer()->getByType(OtherMethodQueryBuilderParser::class),
+			true,
+			true
+		);
 	}
 
 	public function testRule(): void
@@ -39,10 +45,6 @@ class QueryBuilderDqlRuleSlowTest extends RuleTestCase
 			[
 				'QueryBuilder: [Semantical Error] line 0, col 14 near \'Foo e\': Error: Class \'Foo\' is not defined.',
 				71,
-			],
-			[
-				'Could not analyse QueryBuilder with unknown beginning.',
-				89,
 			],
 			[
 				'Could not analyse QueryBuilder with dynamic arguments.',

--- a/tests/Rules/Doctrine/ORM/QueryBuilderDqlRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/QueryBuilderDqlRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Doctrine\ORM;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+use PHPStan\Type\Doctrine\QueryBuilder\OtherMethodQueryBuilderParser;
 
 /**
  * @extends RuleTestCase<QueryBuilderDqlRule>
@@ -14,7 +15,12 @@ class QueryBuilderDqlRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new QueryBuilderDqlRule(new ObjectMetadataResolver(__DIR__ . '/entity-manager.php'), true);
+		return new QueryBuilderDqlRule(
+			new ObjectMetadataResolver(__DIR__ . '/entity-manager.php'),
+			self::getContainer()->getByType(OtherMethodQueryBuilderParser::class),
+			true,
+			true
+		);
 	}
 
 	public function testRule(): void
@@ -39,10 +45,6 @@ class QueryBuilderDqlRuleTest extends RuleTestCase
 			[
 				'QueryBuilder: [Semantical Error] line 0, col 14 near \'Foo e\': Error: Class \'Foo\' is not defined.',
 				71,
-			],
-			[
-				'Could not analyse QueryBuilder with unknown beginning.',
-				89,
 			],
 			[
 				'Could not analyse QueryBuilder with dynamic arguments.',


### PR DESCRIPTION
Without this, I'm getting this error even when type infering works perfectly thanks to other methods analysis. This makes me unable to enable `reportDynamicQueryBuilders: true`.