### PR TITLE
QueryBuilder: allow dynamic args in methods not affecting result type

### DIFF
--- a/src/Type/Doctrine/QueryBuilder/QueryBuilderGetQueryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/QueryBuilderGetQueryDynamicReturnTypeExtension.php
@@ -32,6 +32,21 @@ use function strtolower;
 class QueryBuilderGetQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
+	/**
+	 * Those are critical methods where we need to understand arguments passed to them, the rest is allowed to be more dynamic
+	 * - this list reflects what is implemented in QueryResultTypeWalker
+	 */
+	const METHODS_AFFECTING_RESULT_TYPE = [
+		'add',
+		'select',
+		'addselect',
+		'from',
+		'join',
+		'innerjoin',
+		'leftjoin',
+		'indexby',
+	];
+
 	/** @var ObjectMetadataResolver */
 	private $objectMetadataResolver;
 
@@ -139,6 +154,9 @@ class QueryBuilderGetQueryDynamicReturnTypeExtension implements DynamicMethodRet
 				try {
 					$args = $this->argumentsProcessor->processArgs($scope, $methodName, $calledMethodCall->getArgs());
 				} catch (DynamicQueryBuilderArgumentException $e) {
+					if (!in_array($lowerMethodName, self::METHODS_AFFECTING_RESULT_TYPE, true)) {
+						continue;
+					}
 					return $defaultReturnType;
 				}
 

--- a/src/Type/Doctrine/QueryBuilder/QueryBuilderGetQueryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/QueryBuilderGetQueryDynamicReturnTypeExtension.php
@@ -36,7 +36,7 @@ class QueryBuilderGetQueryDynamicReturnTypeExtension implements DynamicMethodRet
 	 * Those are critical methods where we need to understand arguments passed to them, the rest is allowed to be more dynamic
 	 * - this list reflects what is implemented in QueryResultTypeWalker
 	 */
-	const METHODS_AFFECTING_RESULT_TYPE = [
+	private const METHODS_AFFECTING_RESULT_TYPE = [
 		'add',
 		'select',
 		'addselect',

--- a/tests/Rules/Doctrine/ORM/QueryBuilderDqlRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/QueryBuilderDqlRuleTest.php
@@ -134,6 +134,19 @@ class QueryBuilderDqlRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testDynamicWhere(): void
+	{
+		$this->analyse([__DIR__ . '/data/query-builder-dynamic.php'], [
+			['Could not analyse QueryBuilder with dynamic arguments.', 40],
+			['Could not analyse QueryBuilder with dynamic arguments.', 45],
+			['Could not analyse QueryBuilder with dynamic arguments.', 51],
+			['Could not analyse QueryBuilder with dynamic arguments.', 56],
+			['Could not analyse QueryBuilder with dynamic arguments.', 61],
+			['Could not analyse QueryBuilder with dynamic arguments.', 66],
+			['Could not analyse QueryBuilder with dynamic arguments.', 71],
+		]);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Rules/Doctrine/ORM/data/query-builder-dynamic.php
+++ b/tests/Rules/Doctrine/ORM/data/query-builder-dynamic.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr\Andx;
+use Doctrine\ORM\Query\Expr\From;
+
+class DynamicCalls
+{
+	public function testDynamicMethodCall(
+		EntityManagerInterface $em,
+		Andx $and,
+		Criteria $criteria,
+		string $string
+	): void
+	{
+		$em->createQueryBuilder()
+			->select('m')
+			->from(MyEntity::class, 'm')
+			->andWhere($and)
+			->setParameter($string, $string)
+			->setParameters([$string])
+			->orWhere($string)
+			->addOrderBy($string)
+			->addGroupBy($string)
+			->addCriteria($criteria)
+			->getQuery();
+
+		$em->createQueryBuilder()
+			->select('m')
+			->add('from', new From(MyEntity::class, 'm', null), true)
+			->where($string)
+			->orderBy($string)
+			->groupBy($string)
+			->getQuery();
+
+		// all below are disallowed dynamic
+		$em->createQueryBuilder()
+			->select('m')
+			->from($string, 'm')
+			->getQuery();
+
+		$em->createQueryBuilder()
+			->select('m')
+			->from(MyEntity::class, 'm')
+			->indexBy($string, $string)
+			->getQuery();
+
+		$em->createQueryBuilder()
+			->select('m')
+			->from(MyEntity::class, 'm', $string)
+			->getQuery();
+
+		$em->createQueryBuilder()
+			->select([$string])
+			->from(MyEntity::class, 'm')
+			->getQuery();
+
+		$em->createQueryBuilder()
+			->select(['m'])
+			->from(MyEntity::class, $string)
+			->getQuery();
+
+		$em->createQueryBuilder()
+			->addSelect($string)
+			->from(MyEntity::class, 'm')
+			->getQuery();
+
+		$em->createQueryBuilder()
+			->addSelect('m')
+			->from(MyEntity::class, 'm')
+			->join($string, $string)
+			->getQuery();
+	}
+
+}

--- a/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
@@ -2,8 +2,11 @@
 
 namespace QueryResult\CreateQuery;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr\Andx;
+use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\QueryBuilder;
 use QueryResult\Entities\Many;
 use function PHPStan\Testing\assertType;
@@ -135,7 +138,99 @@ class QueryBuilderGetQuery
 				 ->getQuery();
 
 		assertType('Doctrine\ORM\Query<void, void>', $query);
+	}
 
+
+	public function testDynamicMethodCall(
+		EntityManagerInterface $em,
+		Andx $and,
+		Criteria $criteria,
+		string $string
+	): void
+	{
+		$result = $em->createQueryBuilder()
+			->select('m')
+			->from(Many::class, 'm')
+			->andWhere($and)
+			->setParameter($string, $string)
+			->setParameters([$string])
+			->orWhere($string)
+			->addOrderBy($string)
+			->addGroupBy($string)
+			->addCriteria($criteria)
+			->getQuery()
+			->getResult();
+
+		assertType('list<QueryResult\Entities\Many>', $result);
+
+		$result = $em->createQueryBuilder()
+			->select(['m.stringNullColumn'])
+			->add('from', new From(Many::class, 'm', null), true)
+			->where($string)
+			->orderBy($string)
+			->groupBy($string)
+			->getQuery()
+			->getResult();
+
+		assertType('list<array{stringNullColumn: string|null}>', $result);
+
+		$result = $em->createQueryBuilder()
+			->select(['m.intColumn', 'm.stringNullColumn'])
+			->from($string, 'm')
+			->getQuery()
+			->getResult();
+
+		assertType('mixed', $result);
+
+		$result = $em->createQueryBuilder()
+			->select(['m.intColumn', 'm.stringNullColumn'])
+			->from(Many::class, 'm')
+			->indexBy($string, $string)
+			->getQuery()
+			->getResult();
+
+		assertType('mixed', $result);
+
+		$result = $em->createQueryBuilder()
+			->select('m')
+			->from(Many::class, 'm', $string)
+			->getQuery()
+			->getResult();
+
+		assertType('mixed', $result);
+
+		$result = $em->createQueryBuilder()
+			->select([$string, 'm.stringNullColumn'])
+			->from(Many::class, 'm')
+			->getQuery()
+			->getResult();
+
+		assertType('mixed', $result);
+
+		$result = $em->createQueryBuilder()
+			->select(['m.stringNullColumn'])
+			->from(Many::class, $string)
+			->getQuery()
+			->getResult();
+
+		assertType('mixed', $result);
+
+		$result = $em->createQueryBuilder()
+			->addSelect($string)
+			->from(Many::class, 'm')
+			->getQuery()
+			->getResult();
+
+		assertType('mixed', $result);
+
+		$result = $em->createQueryBuilder()
+			->addSelect('m')
+			->from(Many::class, 'm')
+			->join($string, $string)
+			->getQuery()
+			->getResult();
+
+		assertType('mixed', $result);
 	}
 
 	public function testQueryTypeIsInferredOnAcrossMethods(EntityManagerInterface $em): void


### PR DESCRIPTION
I believe it does not make sense to produce `mixed` just becase this extension does not understand e.g. some `->andWhere` call as this call does not contribute to the inferred result. 

This MR adds a list where we remain strict as before (select, from, indexBy etc) and the rest is allowed to have dynamic arguments.