### PR TITLE
OtherMethodQueryBuilderParser: prevent broken type infering with partial analysis

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -72,6 +72,21 @@ conditionalTags:
 		phpstan.broker.methodsClassReflectionExtension: %doctrine.allCollectionsSelectable%
 
 services:
+	otherMethodAnalysisParser: # identical to defaultAnalysisParser, but uses inner PathRoutingParser without cleaning parser
+		class: PHPStan\Parser\CachedParser
+		arguments:
+			originalParser: @pathRoutingParser
+			cachedNodesByStringCountMax: %cache.nodesByStringCountMax%
+		autowired: false
+
+	pathRoutingOtherMethodAnalysisParser: # identical to pathRoutingParser, but no cleaning parser is used
+		class: PHPStan\Parser\PathRoutingParser
+		arguments:
+			currentPhpVersionRichParser: @currentPhpVersionRichParser
+			currentPhpVersionSimpleParser: @currentPhpVersionRichParser
+			php8Parser: @php8Parser
+		autowired: false
+
 	-
 		class: PHPStan\Type\Doctrine\DescriptorRegistryFactory
 	-
@@ -164,7 +179,7 @@ services:
 		class: PHPStan\Type\Doctrine\QueryBuilder\OtherMethodQueryBuilderParser
 		arguments:
 			descendIntoOtherMethods: %doctrine.searchOtherMethodsForQueryBuilderBeginning%
-			parser: @defaultAnalysisParser
+			parser: @otherMethodAnalysisParser
 
 	-
 		class: PHPStan\Stubs\Doctrine\StubFilesExtensionLoader

--- a/extension.neon
+++ b/extension.neon
@@ -75,7 +75,7 @@ services:
 	otherMethodAnalysisParser: # identical to defaultAnalysisParser, but uses inner PathRoutingParser without cleaning parser
 		class: PHPStan\Parser\CachedParser
 		arguments:
-			originalParser: @pathRoutingParser
+			originalParser: @pathRoutingOtherMethodAnalysisParser
 			cachedNodesByStringCountMax: %cache.nodesByStringCountMax%
 		autowired: false
 


### PR DESCRIPTION
Currently, when a file [is not among "analysed files"](https://github.com/phpstan/phpstan-src/blob/1.10.47/src/Parser/PathRoutingParser.php#L44) (which is any file not listed in partial analysis), every method body is [stripped by CleaningParser](https://github.com/phpstan/phpstan-src/blob/1.10.47/src/Parser/CleaningVisitor.php#L29). Due to that [OtherMethodQueryBuilderParser](https://github.com/phpstan/phpstan-doctrine/blob/1.3.53/src/Type/Doctrine/QueryBuilder/OtherMethodQueryBuilderParser.php#L95) cannot determine what is happening to the QueryBuilder there and results in `mixed`. This results in nasty:

- **partial analysis**: `mixed` returned
- **full analysis**: `list<Entity>` returned

Due to the nature of this feature (affecting only methods returning QueryBuilder) I think it is safe to remove the CleaningParser even with [this improvement](https://github.com/phpstan/phpstan-doctrine/pull/500).