### PR TITLE
Add test for #501

### DIFF
--- a/tests/Type/Doctrine/data/QueryResult/Entities/Vehicle.php
+++ b/tests/Type/Doctrine/data/QueryResult/Entities/Vehicle.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Type\Doctrine\data\QueryResult\Entities;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+interface VehicleInterface
+{
+
+}
+
+/**
+ * @Entity
+ */
+class Car implements VehicleInterface
+{
+	/**
+	 * @GeneratedValue()
+	 * @Column(type="integer")
+	 * @Id
+	 *
+	 * @var string
+	 */
+	public $id;
+}
+
+/**
+ * @Entity
+ */
+class Truck implements VehicleInterface
+{
+	/**
+	 * @GeneratedValue()
+	 * @Column(type="integer")
+	 * @Id
+	 *
+	 * @var string
+	 */
+	public $id;
+}

--- a/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
@@ -128,7 +128,7 @@ class QueryBuilderGetQuery
 
 		$query = $em->createQueryBuilder()
 			->select('v')
-			->from($vehicle::class, 'v')
+			->from(get_class($vehicle), 'v')
 			->getQuery();
 
 		assertType('Doctrine\ORM\Query<null, mixed>', $query);

--- a/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
@@ -9,6 +9,8 @@ use Doctrine\ORM\Query\Expr\Andx;
 use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\QueryBuilder;
 use QueryResult\Entities\Many;
+use Type\Doctrine\data\QueryResult\Entities\Truck;
+use Type\Doctrine\data\QueryResult\Entities\VehicleInterface;
 use function PHPStan\Testing\assertType;
 
 class QueryBuilderGetQuery
@@ -116,6 +118,20 @@ class QueryBuilderGetQuery
 			->getQuery();
 
 		assertType('Doctrine\ORM\Query<mixed, mixed>', $query);
+	}
+
+	public function testQueryResultTypeIsMixedWhenDQLIsUsingAnInterfaceTypeDefinition(EntityManagerInterface $em): void
+	{
+		$vehicle = $this->createVehicule();
+
+		assertType(VehicleInterface::class, $vehicle);
+
+		$query = $em->createQueryBuilder()
+			->select('v')
+			->from($vehicle::class, 'v')
+			->getQuery();
+
+		assertType('Doctrine\ORM\Query<null, mixed>', $query);
 	}
 
 	public function testQueryResultTypeIsVoidWithDeleteOrUpdate(EntityManagerInterface $em): void
@@ -260,5 +276,10 @@ class QueryBuilderGetQuery
 		}
 
 		return $queryBuilder;
+	}
+
+	private function createVehicule(): VehicleInterface
+	{
+		return new Truck();
 	}
 }


### PR DESCRIPTION
Hi,

I wanted to provide a failing test case for #501, but in fact it's not failing at all 😕
Maybe the issue is coming from our side... 

However, it can be useful to merge this test as it covers another case when an phpdoc-typed interface can be passed to `->from()`.