### PR TITLE
Improve QueryResultDynamicReturnTypeExtension

### DIFF
--- a/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
@@ -199,9 +199,14 @@ final class QueryResultDynamicReturnTypeExtension implements DynamicMethodReturn
 					return new MixedType();
 				}
 
-				return $objectManager->getMetadataFactory()->hasMetadataFor($type->getClassName())
-					? new ArrayType(new MixedType(), new MixedType())
-					: $traverse($type);
+				if (!$objectManager->getMetadataFactory()->hasMetadataFor($type->getClassName())) {
+					return $traverse($type);
+				}
+
+				// We could return `new ArrayTyp(new MixedType(), new MixedType())`
+				// but the lack of precision in the array keys/values would give false positive
+				// @see https://github.com/phpstan/phpstan-doctrine/pull/412#issuecomment-1497092934
+				return new MixedType();
 			}
 		);
 	}

--- a/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
@@ -154,7 +154,7 @@ final class QueryResultDynamicReturnTypeExtension implements DynamicMethodReturn
 				return $this->originalReturnType($methodReflection);
 		}
 
-		if (null === $queryResultType) {
+		if ($queryResultType === null) {
 			return $this->originalReturnType($methodReflection);
 		}
 
@@ -275,7 +275,7 @@ final class QueryResultDynamicReturnTypeExtension implements DynamicMethodReturn
 	private function getSingleScalarHydratedReturnType(Type $queryResultType): ?Type
 	{
 		$queryResultType = $this->getScalarHydratedReturnType($queryResultType);
-		if (null === $queryResultType || !$queryResultType->isConstantArray()->yes()) {
+		if ($queryResultType === null || !$queryResultType->isConstantArray()->yes()) {
 			return null;
 		}
 
@@ -295,7 +295,7 @@ final class QueryResultDynamicReturnTypeExtension implements DynamicMethodReturn
 	private function getScalarColumnHydratedReturnType(Type $queryResultType): ?Type
 	{
 		$queryResultType = $this->getScalarHydratedReturnType($queryResultType);
-		if (null === $queryResultType || !$queryResultType->isConstantArray()->yes()) {
+		if ($queryResultType === null || !$queryResultType->isConstantArray()->yes()) {
 			return null;
 		}
 

--- a/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/Query/QueryResultDynamicReturnTypeExtension.php
@@ -220,7 +220,9 @@ final class QueryResultDynamicReturnTypeExtension implements DynamicMethodReturn
 					return new MixedType();
 				}
 
-				if (!$objectManager->getMetadataFactory()->hasMetadataFor($type->getClassName())) {
+				/** @var class-string $className */
+				$className = $type->getClassName();
+				if (!$objectManager->getMetadataFactory()->hasMetadataFor($className)) {
 					return $traverse($type);
 				}
 

--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -850,6 +850,8 @@ class QueryResultTypeWalker extends SqlWalker
 				// Here we assume that the value may or may not be casted to
 				// string by the driver.
 				$casted = false;
+				$originalType = $type;
+
 				$type = TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$casted): Type {
 					if ($type instanceof UnionType || $type instanceof IntersectionType) {
 						return $traverse($type);
@@ -867,7 +869,7 @@ class QueryResultTypeWalker extends SqlWalker
 
 				// Since we made supposition about possibly casted values,
 				// we can only provide a benevolent union.
-				if ($casted && $type instanceof UnionType) {
+				if ($casted && $type instanceof UnionType && !$originalType->equals($type)) {
 					$type = TypeUtils::toBenevolentUnion($type);
 				}
 			}

--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -797,7 +797,7 @@ class QueryResultTypeWalker extends SqlWalker
 
 			$type = $this->resolveDoctrineType($typeName, $enumType, $nullable);
 
-			$this->typeBuilder->addScalar($resultAlias, $type);
+			$this->addScalar($resultAlias, $type);
 
 			return '';
 		}
@@ -857,7 +857,7 @@ class QueryResultTypeWalker extends SqlWalker
 				});
 			}
 
-			$this->typeBuilder->addScalar($resultAlias, $type);
+			$this->addScalar($resultAlias, $type);
 
 			return '';
 		}
@@ -1296,6 +1296,18 @@ class QueryResultTypeWalker extends SqlWalker
 	public function walkResultVariable($resultVariable): string
 	{
 		return $this->marshalType(new MixedType());
+	}
+
+	/**
+	 * @param array-key $alias
+	 */
+	private function addScalar($alias, Type $type): void
+	{
+		if ($type instanceof UnionType) {
+			$type = TypeUtils::toBenevolentUnion($type);
+		}
+
+		$this->typeBuilder->addScalar($alias, $type);
 	}
 
 	private function unmarshalType(string $marshalledType): Type

--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -849,18 +849,27 @@ class QueryResultTypeWalker extends SqlWalker
 				// the driver and PHP version.
 				// Here we assume that the value may or may not be casted to
 				// string by the driver.
-				$type = TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+				$casted = false;
+				$type = TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$casted): Type {
 					if ($type instanceof UnionType || $type instanceof IntersectionType) {
 						return $traverse($type);
 					}
 					if ($type instanceof IntegerType || $type instanceof FloatType) {
+						$casted = true;
 						return TypeCombinator::union($type->toString(), $type);
 					}
 					if ($type instanceof BooleanType) {
+						$casted = true;
 						return TypeCombinator::union($type->toInteger()->toString(), $type);
 					}
 					return $traverse($type);
 				});
+
+				// Since we made supposition about possibly casted values,
+				// we can only provide a benevolent union.
+				if ($casted && $type instanceof UnionType) {
+					$type = TypeUtils::toBenevolentUnion($type);
+				}
 			}
 
 			$this->addScalar($resultAlias, $type);

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -455,7 +455,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				[new ConstantStringType('stringColumn'), new StringType()],
 				[
 					new ConstantStringType('stringNullColumn'),
-					TypeUtils::toBenevolentUnion(TypeCombinator::addNull(new StringType()))
+					TypeUtils::toBenevolentUnion(TypeCombinator::addNull(new StringType())),
 				],
 				[new ConstantStringType('datetimeColumn'), new ObjectType(DateTime::class)],
 				[new ConstantStringType('datetimeImmutableColumn'), new ObjectType(DateTimeImmutable::class)],

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -449,6 +449,25 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			',
 		];
 
+		yield 'scalar with where condition' => [
+			$this->constantArray([
+				[new ConstantStringType('intColumn'), new IntegerType()],
+				[new ConstantStringType('stringColumn'), new StringType()],
+				[
+					new ConstantStringType('stringNullColumn'),
+					TypeUtils::toBenevolentUnion(TypeCombinator::addNull(new StringType()))
+				],
+				[new ConstantStringType('datetimeColumn'), new ObjectType(DateTime::class)],
+				[new ConstantStringType('datetimeImmutableColumn'), new ObjectType(DateTimeImmutable::class)],
+			]),
+			'
+				SELECT		m.intColumn, m.stringColumn, m.stringNullColumn,
+							m.datetimeColumn, m.datetimeImmutableColumn
+				FROM		QueryResult\Entities\Many m
+				WHERE       m.stringNullColumn IS NOT NULL
+			',
+		];
+
 		yield 'scalar with alias' => [
 			$this->constantArray([
 				[new ConstantStringType('i'), new IntegerType()],

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -13,7 +13,6 @@ use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
-use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -30,7 +29,6 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use QueryResult\Entities\Embedded;
 use QueryResult\Entities\JoinedChild;
@@ -1343,7 +1341,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					new ConstantIntegerType(2),
 					$this->hasTypedExpressions()
 					? $this->uint(true)
-					: $this->uintStringified(true)
+					: $this->uintStringified(true),
 				],
 				[
 					new ConstantIntegerType(3),
@@ -1670,7 +1668,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		$types = [
 			new FloatType(),
 			IntegerRangeType::fromInterval(0, null),
-			$this->numericString()
+			$this->numericString(),
 		];
 		if ($nullable) {
 			$types[] = new NullType();

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -704,63 +704,63 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantStringType('1'),
 						new ConstantIntegerType(1),
 						new NullType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(2),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantStringType('0'),
 						new ConstantIntegerType(0),
 						new ConstantStringType('1'),
 						new ConstantIntegerType(1),
 						new NullType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(3),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantStringType('1'),
 						new ConstantIntegerType(1),
 						new NullType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(4),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantStringType('0'),
 						new ConstantIntegerType(0),
 						new ConstantStringType('1'),
 						new ConstantIntegerType(1),
 						new NullType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(5),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						$this->intStringified(),
 						new FloatType(),
 						new NullType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(6),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						$this->intStringified(),
 						new FloatType(),
 						new NullType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(7),
-					TypeCombinator::addNull($this->intStringified()),
+					TypeUtils::toBenevolentUnion(TypeCombinator::addNull($this->intStringified())),
 				],
 				[
 					new ConstantIntegerType(8),
-					TypeCombinator::addNull($this->intStringified()),
+					TypeUtils::toBenevolentUnion(TypeCombinator::addNull($this->intStringified())),
 				],
 			]),
 			'

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -797,10 +797,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeUtils::toBenevolentUnion(TypeCombinator::union(
+					TypeCombinator::union(
 						new StringType(),
 						new IntegerType()
-					)),
+					),
 				],
 				[
 					new ConstantIntegerType(2),
@@ -826,10 +826,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeUtils::toBenevolentUnion(TypeCombinator::union(
+					TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					)),
+					),
 				],
 			]),
 			'
@@ -846,10 +846,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeUtils::toBenevolentUnion(TypeCombinator::union(
+					TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					)),
+					),
 				],
 			]),
 			'

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -28,6 +29,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use QueryResult\Entities\Embedded;
@@ -551,12 +553,12 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					],
 					[
 						new ConstantIntegerType(2),
-						TypeCombinator::union(
+						TypeUtils::toBenevolentUnion(TypeCombinator::union(
 							new ConstantIntegerType(1),
 							new ConstantIntegerType(2),
 							new ConstantStringType('1'),
 							new ConstantStringType('2')
-						),
+						)),
 					],
 					[
 						new ConstantIntegerType(3),
@@ -603,7 +605,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantIntegerType(2),
@@ -617,7 +619,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(4),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantIntegerType(5),
@@ -627,7 +629,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(6),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantIntegerType(7),
@@ -653,7 +655,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantStringType('max'),
-					TypeCombinator::addNull($this->intStringified()),
+					$this->intStringified(true),
 				],
 				[
 					new ConstantStringType('arithmetic'),
@@ -761,10 +763,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantStringType('1'),
 						new ConstantIntegerType(1)
-					),
+					)),
 				],
 				[new ConstantIntegerType(2), new ConstantStringType('hello')],
 			]),
@@ -778,11 +780,11 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(1),
 						new ConstantStringType('1'),
 						new NullType()
-					),
+					)),
 				],
 			]),
 			'
@@ -795,10 +797,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new StringType(),
 						new IntegerType()
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(2),
@@ -824,10 +826,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					),
+					)),
 				],
 			]),
 			'
@@ -844,10 +846,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new StringType(),
 						new ConstantIntegerType(0)
-					),
+					)),
 				],
 			]),
 			'
@@ -864,12 +866,12 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantIntegerType(1),
 						new ConstantStringType('0'),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 			]),
 			'
@@ -885,12 +887,12 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantIntegerType(1),
 						new ConstantStringType('0'),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 			]),
 			'
@@ -906,31 +908,31 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			$this->constantArray([
 				[
 					new ConstantIntegerType(1),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(1),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(2),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantStringType('0')
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(3),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(1),
 						new ConstantStringType('1')
-					),
+					)),
 				],
 				[
 					new ConstantIntegerType(4),
-					TypeCombinator::union(
+					TypeUtils::toBenevolentUnion(TypeCombinator::union(
 						new ConstantIntegerType(0),
 						new ConstantStringType('0')
-					),
+					)),
 				],
 			]),
 			'
@@ -1102,10 +1104,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					],
 					[
 						new ConstantIntegerType(2),
-						TypeCombinator::union(
+						TypeUtils::toBenevolentUnion(TypeCombinator::union(
 							new ConstantIntegerType(1),
 							new ConstantStringType('1')
-						),
+						)),
 					],
 					[
 						new ConstantStringType('intColumn'),
@@ -1149,7 +1151,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'new arguments affect scalar counter' => [
 			$this->constantArray([
-				[new ConstantIntegerType(5), TypeCombinator::addNull($this->intStringified())],
+				[new ConstantIntegerType(5), $this->intStringified(true)],
 				[new ConstantIntegerType(0), new ObjectType(ManyId::class)],
 				[new ConstantIntegerType(1), new ObjectType(OneId::class)],
 			]),
@@ -1166,7 +1168,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				[new ConstantStringType('intColumn'), new IntegerType()],
 				[new ConstantIntegerType(1), $this->intStringified()],
 				[new ConstantIntegerType(2), $this->intStringified()],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->intStringified())],
+				[new ConstantIntegerType(3), $this->intStringified(true)],
 				[new ConstantIntegerType(4), $this->intStringified()],
 				[new ConstantIntegerType(5), $this->intStringified()],
 				[new ConstantIntegerType(6), $this->numericStringified()],
@@ -1188,9 +1190,9 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'abs function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->unumericStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->unumericStringified())],
+				[new ConstantIntegerType(2), $this->unumericStringified(true)],
 				[new ConstantIntegerType(3), $this->unumericStringified()],
-				[new ConstantIntegerType(4), TypeCombinator::union($this->unumericStringified())],
+				[new ConstantIntegerType(4), $this->unumericStringified()],
 			]),
 			'
 				SELECT		ABS(m.intColumn),
@@ -1204,7 +1206,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'bit_and function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->uintStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(2), $this->uintStringified(true)],
 				[new ConstantIntegerType(3), $this->uintStringified()],
 			]),
 			'
@@ -1218,7 +1220,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'bit_or function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->uintStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(2), $this->uintStringified(true)],
 				[new ConstantIntegerType(3), $this->uintStringified()],
 			]),
 			'
@@ -1296,8 +1298,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'date_diff function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->numericStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->numericStringified())],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->numericStringified())],
+				[new ConstantIntegerType(2), $this->numericStringified(true)],
+				[new ConstantIntegerType(3), $this->numericStringified(true)],
 				[new ConstantIntegerType(4), $this->numericStringified()],
 			]),
 			'
@@ -1339,11 +1341,9 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				],
 				[
 					new ConstantIntegerType(2),
-					TypeCombinator::addNull(
-						$this->hasTypedExpressions()
-						? $this->uint()
-						: $this->uintStringified()
-					),
+					$this->hasTypedExpressions()
+					? $this->uint(true)
+					: $this->uintStringified(true)
 				],
 				[
 					new ConstantIntegerType(3),
@@ -1364,8 +1364,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 			yield 'locate function' => [
 				$this->constantArray([
 					[new ConstantIntegerType(1), $this->uintStringified()],
-					[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
-					[new ConstantIntegerType(3), TypeCombinator::addNull($this->uintStringified())],
+					[new ConstantIntegerType(2), $this->uintStringified(true)],
+					[new ConstantIntegerType(3), $this->uintStringified(true)],
 					[new ConstantIntegerType(4), $this->uintStringified()],
 				]),
 				'
@@ -1407,8 +1407,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		yield 'mod function' => [
 			$this->constantArray([
 				[new ConstantIntegerType(1), $this->uintStringified()],
-				[new ConstantIntegerType(2), TypeCombinator::addNull($this->uintStringified())],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(2), $this->uintStringified(true)],
+				[new ConstantIntegerType(3), $this->uintStringified(true)],
 				[new ConstantIntegerType(4), $this->uintStringified()],
 			]),
 			'
@@ -1422,7 +1422,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'mod function error' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->uintStringified())],
+				[new ConstantIntegerType(1), $this->uintStringified(true)],
 			]),
 			'
 				SELECT		MOD(10, NULLIF(m.intColumn, m.intColumn))
@@ -1481,15 +1481,15 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'identity function' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
-				[new ConstantIntegerType(2), $this->numericStringOrInt()],
-				[new ConstantIntegerType(3), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
+				[new ConstantIntegerType(2), $this->intStringified()],
+				[new ConstantIntegerType(3), $this->intStringified(true)],
 				[new ConstantIntegerType(4), TypeCombinator::addNull(new StringType())],
 				[new ConstantIntegerType(5), TypeCombinator::addNull(new StringType())],
-				[new ConstantIntegerType(6), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(6), $this->intStringified(true)],
 				[new ConstantIntegerType(7), TypeCombinator::addNull(new MixedType())],
-				[new ConstantIntegerType(8), TypeCombinator::addNull($this->numericStringOrInt())],
-				[new ConstantIntegerType(9), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(8), $this->intStringified(true)],
+				[new ConstantIntegerType(9), $this->intStringified(true)],
 			]),
 			'
 				SELECT		IDENTITY(m.oneNull),
@@ -1508,7 +1508,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select nullable association' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
 			]),
 			'
 				SELECT		DISTINCT(m.oneNull)
@@ -1518,7 +1518,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select non null association' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), $this->numericStringOrInt()],
+				[new ConstantIntegerType(1), $this->intStringified()],
 			]),
 			'
 				SELECT		DISTINCT(m.one)
@@ -1528,7 +1528,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select default nullability association' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
 			]),
 			'
 				SELECT		DISTINCT(m.oneDefaultNullability)
@@ -1538,7 +1538,7 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 
 		yield 'select non null association in aggregated query' => [
 			$this->constantArray([
-				[new ConstantIntegerType(1), TypeCombinator::addNull($this->numericStringOrInt())],
+				[new ConstantIntegerType(1), $this->intStringified(true)],
 				[
 					new ConstantIntegerType(2),
 					$this->hasTypedExpressions()
@@ -1608,17 +1608,6 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		return $builder->getArray();
 	}
 
-	private function numericStringOrInt(): Type
-	{
-		return new UnionType([
-			new IntegerType(),
-			new IntersectionType([
-				new StringType(),
-				new AccessoryNumericStringType(),
-			]),
-		]);
-	}
-
 	private function numericString(): Type
 	{
 		return new IntersectionType([
@@ -1627,42 +1616,67 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 		]);
 	}
 
-	private function uint(): Type
+	private function uint(bool $nullable = false): Type
 	{
-		return IntegerRangeType::fromInterval(0, null);
+		$type = IntegerRangeType::fromInterval(0, null);
+		if ($nullable) {
+			TypeCombinator::addNull($type);
+		}
+
+		return $type;
 	}
 
-	private function intStringified(): Type
+	private function intStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			new IntegerType(),
-			$this->numericString()
-		);
+			$this->numericString(),
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
-	private function uintStringified(): Type
+	private function uintStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			$this->uint(),
-			$this->numericString()
-		);
+			$this->numericString(),
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
 
-	private function numericStringified(): Type
+	private function numericStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			new FloatType(),
 			new IntegerType(),
-			$this->numericString()
-		);
+			$this->numericString(),
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
 
-	private function unumericStringified(): Type
+	private function unumericStringified(bool $nullable = false): Type
 	{
-		return TypeCombinator::union(
+		$types = [
 			new FloatType(),
 			IntegerRangeType::fromInterval(0, null),
 			$this->numericString()
-		);
+		];
+		if ($nullable) {
+			$types[] = new NullType();
+		}
+
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(...$types));
 	}
 
 	private function hasTypedExpressions(): bool

--- a/tests/Type/Doctrine/data/QueryResult/queryResult.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryResult.php
@@ -384,31 +384,31 @@ class QueryResultTest
 		');
 
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->getResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->getSingleScalarResult()
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->execute(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string',
+			'(int<0, max>|numeric-string)',
 			$query->getSingleResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'int<0, max>|numeric-string|null',
+			'(int<0, max>|numeric-string|null)',
 			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 	}

--- a/tests/Type/Doctrine/data/QueryResult/queryResult.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryResult.php
@@ -144,11 +144,167 @@ class QueryResultTest
 	}
 
 	/**
-	 * Test that we properly infer the return type of Query methods with explicit hydration mode that is not HYDRATE_OBJECT
+	 * Test that we properly infer the return type of Query methods with explicit hydration mode of HYDRATE_ARRAY
 	 *
-	 * We are never able to infer the return type here
+	 * We can infer the return type by changing every object by an array
 	 */
-	public function testReturnTypeOfQueryMethodsWithExplicitNonObjectHydrationMode(EntityManagerInterface $em): void
+	public function testReturnTypeOfQueryMethodsWithExplicitArrayHydrationMode(EntityManagerInterface $em): void
+	{
+		$query = $em->createQuery('
+			SELECT		m
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<array>',
+			$query->getResult(AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'list<array>',
+			$query->getArrayResult()
+		);
+		assertType(
+			'iterable<int, array>',
+			$query->toIterable([], AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'list<array>',
+			$query->execute(null, AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'list<array>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'list<array>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'array',
+			$query->getSingleResult(AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'array|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)
+		);
+
+		$query = $em->createQuery('
+			SELECT		m.intColumn, m.stringNullColumn, m.datetimeColumn
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
+			$query->getResult(AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
+			$query->getArrayResult()
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
+			$query->execute(null, AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}',
+			$query->getSingleResult(AbstractQuery::HYDRATE_ARRAY)
+		);
+		assertType(
+			'array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)
+		);
+	}
+
+	/**
+	 * Test that we properly infer the return type of Query methods with explicit hydration mode of HYDRATE_SCALAR
+	 */
+	public function testReturnTypeOfQueryMethodsWithExplicitScalarHydrationMode(EntityManagerInterface $em): void
+	{
+		$query = $em->createQuery('
+			SELECT		m
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<array>',
+			$query->getResult(AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'list<array>',
+			$query->getScalarResult()
+		);
+		assertType(
+			'iterable<int, array>',
+			$query->toIterable([], AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'list<array>',
+			$query->execute(null, AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'list<array>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'list<array>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'array',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'array|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SCALAR)
+		);
+
+		$query = $em->createQuery('
+			SELECT		m.intColumn, m.stringNullColumn
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null}>',
+			$query->getResult(AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null}>',
+			$query->getScalarResult()
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null}>',
+			$query->execute(null, AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null}>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'list<array{intColumn: int, stringNullColumn: string|null}>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'array{intColumn: int, stringNullColumn: string|null}',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SCALAR)
+		);
+		assertType(
+			'array{intColumn: int, stringNullColumn: string|null}|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SCALAR)
+		);
+	}
+
+	/**
+	 * Test that we properly infer the return type of Query methods with explicit hydration mode of HYDRATE_SCALAR
+	 */
+	public function testReturnTypeOfQueryMethodsWithExplicitSingleScalarHydrationMode(EntityManagerInterface $em): void
 	{
 		$query = $em->createQuery('
 			SELECT		m
@@ -157,31 +313,255 @@ class QueryResultTest
 
 		assertType(
 			'mixed',
-			$query->getResult(AbstractQuery::HYDRATE_ARRAY)
-		);
-		assertType(
-			'iterable',
-			$query->toIterable([], AbstractQuery::HYDRATE_ARRAY)
+			$query->getResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
 			'mixed',
-			$query->execute(null, AbstractQuery::HYDRATE_ARRAY)
+			$query->getSingleScalarResult()
+		);
+		assertType(
+			'iterable<int, mixed>',
+			$query->toIterable([], AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
 			'mixed',
-			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
+			$query->execute(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
 			'mixed',
-			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
 			'mixed',
-			$query->getSingleResult(AbstractQuery::HYDRATE_ARRAY)
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
 			'mixed',
-			$query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)
+			$query->getSingleResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'mixed',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+
+		$query = $em->createQuery('
+			SELECT		m.intColumn
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'int',
+			$query->getResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int',
+			$query->getSingleScalarResult()
+		);
+		assertType(
+			'int',
+			$query->execute(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+
+		$query = $em->createQuery('
+			SELECT		COUNT(m.id)
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'int<0, max>|numeric-string',
+			$query->getResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int<0, max>|numeric-string',
+			$query->getSingleScalarResult()
+		);
+		assertType(
+			'int<0, max>|numeric-string',
+			$query->execute(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int<0, max>|numeric-string',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int<0, max>|numeric-string',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int<0, max>|numeric-string',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+		assertType(
+			'int<0, max>|numeric-string|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
+		);
+	}
+
+	/**
+	 * Test that we properly infer the return type of Query methods with explicit hydration mode of HYDRATE_SIMPLEOBJECT
+	 *
+	 * We are never able to infer the return type here
+	 */
+	public function testReturnTypeOfQueryMethodsWithExplicitSimpleObjectHydrationMode(EntityManagerInterface $em): void
+	{
+		$query = $em->createQuery('
+			SELECT		m
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<QueryResult\Entities\Many>',
+			$query->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'iterable<int, QueryResult\Entities\Many>',
+			$query->toIterable([], AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'list<QueryResult\Entities\Many>',
+			$query->execute(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'list<QueryResult\Entities\Many>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'list<QueryResult\Entities\Many>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'QueryResult\Entities\Many',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'QueryResult\Entities\Many|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+
+		$query = $em->createQuery('
+			SELECT		m.intColumn, m.stringNullColumn
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<mixed>',
+			$query->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'list<mixed>',
+			$query->execute(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'list<mixed>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'list<mixed>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'mixed',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+		assertType(
+			'mixed',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SIMPLEOBJECT)
+		);
+	}
+
+	/**
+	 * Test that we properly infer the return type of Query methods with explicit hydration mode of HYDRATE_SCALAR_COLUMN
+	 *
+	 * We are never able to infer the return type here
+	 */
+	public function testReturnTypeOfQueryMethodsWithExplicitScalarColumnHydrationMode(EntityManagerInterface $em): void
+	{
+		$query = $em->createQuery('
+			SELECT		m
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<mixed>',
+			$query->getResult(AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'list<mixed>',
+			$query->getSingleColumnResult()
+		);
+		assertType(
+			'iterable<int, mixed>',
+			$query->toIterable([], AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'list<mixed>',
+			$query->execute(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'list<mixed>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'list<mixed>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'mixed',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'mixed',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+
+		$query = $em->createQuery('
+			SELECT		m.intColumn
+			FROM		QueryResult\Entities\Many m
+		');
+
+		assertType(
+			'list<int>',
+			$query->getResult(AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'list<int>',
+			$query->getSingleColumnResult()
+		);
+		assertType(
+			'list<int>',
+			$query->execute(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'list<int>',
+			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'list<int>',
+			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'int',
+			$query->getSingleResult(AbstractQuery::HYDRATE_SCALAR_COLUMN)
+		);
+		assertType(
+			'int|null',
+			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SCALAR_COLUMN)
 		);
 	}
 

--- a/tests/Type/Doctrine/data/QueryResult/queryResult.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryResult.php
@@ -156,27 +156,27 @@ class QueryResultTest
 		');
 
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->getResult(AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<mixed>',
+			'array',
 			$query->getArrayResult()
 		);
 		assertType(
-			'iterable<int, mixed>',
+			'iterable',
 			$query->toIterable([], AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->execute(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
@@ -234,35 +234,35 @@ class QueryResultTest
 		');
 
 		assertType(
-			'list<array>',
+			'mixed',
 			$query->getResult(AbstractQuery::HYDRATE_SCALAR)
 		);
 		assertType(
-			'list<array>',
+			'array',
 			$query->getScalarResult()
 		);
 		assertType(
-			'iterable<int, array>',
+			'iterable',
 			$query->toIterable([], AbstractQuery::HYDRATE_SCALAR)
 		);
 		assertType(
-			'list<array>',
+			'mixed',
 			$query->execute(null, AbstractQuery::HYDRATE_SCALAR)
 		);
 		assertType(
-			'list<array>',
+			'mixed',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SCALAR)
 		);
 		assertType(
-			'list<array>',
+			'mixed',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SCALAR)
 		);
 		assertType(
-			'array',
+			'mixed',
 			$query->getSingleResult(AbstractQuery::HYDRATE_SCALAR)
 		);
 		assertType(
-			'array|null',
+			'mixed',
 			$query->getOneOrNullResult(AbstractQuery::HYDRATE_SCALAR)
 		);
 
@@ -316,11 +316,11 @@ class QueryResultTest
 			$query->getResult(AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
-			'mixed',
+			'bool|float|int|string|null',
 			$query->getSingleScalarResult()
 		);
 		assertType(
-			'iterable<int, mixed>',
+			'iterable',
 			$query->toIterable([], AbstractQuery::HYDRATE_SINGLE_SCALAR)
 		);
 		assertType(
@@ -460,19 +460,19 @@ class QueryResultTest
 		');
 
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->execute(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SIMPLEOBJECT)
 		);
 		assertType(
@@ -498,27 +498,27 @@ class QueryResultTest
 		');
 
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->getResult(AbstractQuery::HYDRATE_SCALAR_COLUMN)
 		);
 		assertType(
-			'list<mixed>',
+			'array',
 			$query->getSingleColumnResult()
 		);
 		assertType(
-			'iterable<int, mixed>',
+			'iterable',
 			$query->toIterable([], AbstractQuery::HYDRATE_SCALAR_COLUMN)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->execute(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
 		);
 		assertType(
-			'list<mixed>',
+			'mixed',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_SCALAR_COLUMN)
 		);
 		assertType(

--- a/tests/Type/Doctrine/data/QueryResult/queryResult.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryResult.php
@@ -156,35 +156,35 @@ class QueryResultTest
 		');
 
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->getResult(AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->getArrayResult()
 		);
 		assertType(
-			'iterable<int, array>',
+			'iterable<int, mixed>',
 			$query->toIterable([], AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->execute(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'list<array>',
+			'list<mixed>',
 			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'array',
+			'mixed',
 			$query->getSingleResult(AbstractQuery::HYDRATE_ARRAY)
 		);
 		assertType(
-			'array|null',
+			'mixed',
 			$query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)
 		);
 


### PR DESCRIPTION
Same as https://github.com/phpstan/phpstan-doctrine/pull/453#issue-1695849185

With the commit https://github.com/phpstan/phpstan-doctrine/commit/1b0a1b09da00f3acabc3873460d34b514461d7ab

I changed the strategy to be easily accepted and then easier to merge:
- If I can precisely infer the type, I return the type
- If not, I rely on the default return type rather than returning an half-precise type like `array<mixed>` => This way we have the same behavior than before and people doesn't get error moving from level 9 to 7-8.

