### PR TITLE
Assure ORM 3 compatibility with property field mappings

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,16 @@ parameters:
 			path: src/Rules/Doctrine/ORM/EntityRelationRule.php
 
 		-
+			message: "#^Class Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping not found\\.$#"
+			count: 1
+			path: src/Rules/Doctrine/ORM/PropertiesExtension.php
+
+		-
+			message: "#^Instanceof between array\\<string, array\\<string, mixed\\>\\|bool\\|int\\|string\\> and Doctrine\\\\ORM\\\\Mapping\\\\FieldMapping will always evaluate to false\\.$#"
+			count: 1
+			path: src/Rules/Doctrine/ORM/PropertiesExtension.php
+
+		-
 			message: "#^PHPDoc tag @var with type class\\-string is not subtype of native type 'Doctrine\\\\\\\\Bundle…'\\.$#"
 			count: 1
 			path: src/Stubs/Doctrine/StubFilesExtensionLoader.php

--- a/src/Rules/Doctrine/ORM/PropertiesExtension.php
+++ b/src/Rules/Doctrine/ORM/PropertiesExtension.php
@@ -3,11 +3,11 @@
 namespace PHPStan\Rules\Doctrine\ORM;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
 use PHPStan\Type\Doctrine\ObjectMetadataResolver;
 use Throwable;
-use function array_key_exists;
 use function in_array;
 
 class PropertiesExtension implements ReadWritePropertiesExtension
@@ -47,7 +47,16 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 
 		if (isset($metadata->fieldMappings[$propertyName])) {
 			$mapping = $metadata->fieldMappings[$propertyName];
-			if (array_key_exists('generated', $mapping) && $mapping['generated'] !== ClassMetadata::GENERATED_NEVER) {
+
+			if ($mapping instanceof FieldMapping) {
+				// ORM 3
+				$generated = $mapping->generated;
+			} else {
+				// ORM 2
+				$generated = $mapping['generated'] ?? null;
+			}
+
+			if ($generated !== ClassMetadata::GENERATED_NEVER) {
 				return true;
 			}
 		}

--- a/src/Rules/Doctrine/ORM/PropertiesExtension.php
+++ b/src/Rules/Doctrine/ORM/PropertiesExtension.php
@@ -56,7 +56,7 @@ class PropertiesExtension implements ReadWritePropertiesExtension
 				$generated = $mapping['generated'] ?? null;
 			}
 
-			if ($generated !== ClassMetadata::GENERATED_NEVER) {
+			if ($generated !== null && $generated !== ClassMetadata::GENERATED_NEVER) {
 				return true;
 			}
 		}


### PR DESCRIPTION
With doctrine/orm#10607, property field mappings were extracted in a separate DTO. However, `phpstan/phpstan-doctrine` does not yet support the modified type and results in an error like follows:

```
Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, Doctrine\ORM\Mapping\FieldMapping given in /xxx/vendor/phpstan/phpstan-doctrine/src/Rules/Doctrine/ORM/PropertiesExtension.php:51
#0 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Rules/DeadCode/UnusedPrivatePropertyRule.php(103): PHPStan\Rules\Doctrine\ORM\PropertiesExtension->isAlwaysWritten(Object(PHPStan\Reflection\Php\PhpPropertyReflection), 'id')
#1 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/FileAnalyser.php(107): PHPStan\Rules\DeadCode\UnusedPrivatePropertyRule->processNode(Object(PHPStan\Node\ClassPropertiesNode), Object(PHPStan\Analyser\MutatingScope))
#2 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php(669): PHPStan\Analyser\FileAnalyser->PHPStan\Analyser\{closure}(Object(PHPStan\Node\ClassPropertiesNode), Object(PHPStan\Analyser\MutatingScope))
#3 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php(401): PHPStan\Analyser\NodeScopeResolver->processStmtNode(Object(PhpParser\Node\Stmt\Class_), Object(PHPStan\Analyser\MutatingScope), Object(Closure), Object(PHPStan\Analyser\StatementContext))
#4 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php(640): PHPStan\Analyser\NodeScopeResolver->processStmtNodes(Object(PhpParser\Node\Stmt\Namespace_), Array, Object(PHPStan\Analyser\MutatingScope), Object(Closure), Object(PHPStan\Analyser\StatementContext))
#5 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php(370): PHPStan\Analyser\NodeScopeResolver->processStmtNode(Object(PhpParser\Node\Stmt\Namespace_), Object(PHPStan\Analyser\MutatingScope), Object(Closure), Object(PHPStan\Analyser\StatementContext))
#6 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/FileAnalyser.php(166): PHPStan\Analyser\NodeScopeResolver->processNodes(Array, Object(PHPStan\Analyser\MutatingScope), Object(Closure))
#7 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/Analyser.php(72): PHPStan\Analyser\FileAnalyser->analyseFile('/xxx/...', Array, Object(PHPStan\Rules\LazyRegistry), Object(PHPStan\Collectors\Registry), NULL)
#8 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyserRunner.php(62): PHPStan\Analyser\Analyser->analyse(Array, Object(Closure), NULL, true, Array)
#9 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseApplication.php(210): PHPStan\Command\AnalyserRunner->runAnalyser(Array, Array, Object(Closure), NULL, true, true, '/xxx/...', Object(_PHPStan_11268e5ee\Symfony\Component\Console\Input\ArgvInput))
#10 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseApplication.php(101): PHPStan\Command\AnalyseApplication->runAnalyser(Array, Array, true, '/xxx/...', Object(PHPStan\Command\Symfony\SymfonyOutput), Object(PHPStan\Command\Symfony\SymfonyOutput), Object(_PHPStan_11268e5ee\Symfony\Component\Console\Input\ArgvInput))
#11 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseCommand.php(200): PHPStan\Command\AnalyseApplication->analyse(Array, false, Object(PHPStan\Command\Symfony\SymfonyOutput), Object(PHPStan\Command\Symfony\SymfonyOutput), false, true, '/xxx/...', Array, Object(_PHPStan_11268e5ee\Symfony\Component\Console\Input\ArgvInput))
#12 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Command/Command.php(259): PHPStan\Command\AnalyseCommand->execute(Object(_PHPStan_11268e5ee\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_11268e5ee\Symfony\Component\Console\Output\ConsoleOutput))
#13 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(870): _PHPStan_11268e5ee\Symfony\Component\Console\Command\Command->run(Object(_PHPStan_11268e5ee\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_11268e5ee\Symfony\Component\Console\Output\ConsoleOutput))
#14 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(261): _PHPStan_11268e5ee\Symfony\Component\Console\Application->doRunCommand(Object(PHPStan\Command\AnalyseCommand), Object(_PHPStan_11268e5ee\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_11268e5ee\Symfony\Component\Console\Output\ConsoleOutput))
#15 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(157): _PHPStan_11268e5ee\Symfony\Component\Console\Application->doRun(Object(_PHPStan_11268e5ee\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_11268e5ee\Symfony\Component\Console\Output\ConsoleOutput))
#16 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(124): _PHPStan_11268e5ee\Symfony\Component\Console\Application->run()
#17 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(125): _PHPStan_11268e5ee\{closure}()
#18 /xxx/vendor/phpstan/phpstan/phpstan(8): require('phar:///xxx/...')
#19 /xxx/vendor/bin/phpstan(119): include('/xxx/...')
#20 {main}
```

This PR tries to fix the issue in a way that both variants (array [ORM 2] & DTO [ORM 3]) are still supported.

Tested and verified with v1.3.60 of `phpstan/phpstan-doctrine`.