### PR TITLE
fix AnnotationDriver check

### DIFF
--- a/src/Doctrine/Mapping/ClassMetadataFactory.php
+++ b/src/Doctrine/Mapping/ClassMetadataFactory.php
@@ -29,7 +29,7 @@ class ClassMetadataFactory extends \Doctrine\ORM\Mapping\ClassMetadataFactory
 	protected function initialize(): void
 	{
 		$drivers = [];
-		if (class_exists(AnnotationReader::class)) {
+		if (class_exists(AnnotationDriver::class) && class_exists(AnnotationReader::class)) {
 			$docParser = new DocParser();
 			$docParser->setIgnoreNotImportedAnnotations(true);
 			$drivers[] = new AnnotationDriver(new AnnotationReader($docParser));


### PR DESCRIPTION
Fixes problem with `doctrine/annotations:*` & `doctrine/orm:^3`  as dependencies at same time