### PR TITLE
Fix aggregate function on litteral

### DIFF
--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -944,11 +944,8 @@ class QueryResultTypeWalker extends SqlWalker
 					$this->walkSimpleArithmeticExpression($aggExpression->pathExpression)
 				);
 
-				if (count($type->getConstantScalarValues()) !== 1) {
-					$type = TypeUtils::generalizeType($type, GeneralizePrecision::lessSpecific());
-				}
-
-				$type = TypeCombinator::union($type, $type->toFloat(), $type->toFloat()->toString());
+				$type = TypeCombinator::union($type, $type->toFloat());
+				$type = TypeUtils::generalizeType($type, GeneralizePrecision::lessSpecific());
 
 				return $this->marshalType(TypeCombinator::addNull($type));
 

--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -933,11 +933,31 @@ class QueryResultTypeWalker extends SqlWalker
 		switch ($aggExpression->functionName) {
 			case 'MAX':
 			case 'MIN':
+				$type = $this->unmarshalType(
+					$this->walkSimpleArithmeticExpression($aggExpression->pathExpression)
+				);
+
+				return $this->marshalType(TypeCombinator::addNull($type));
+
 			case 'AVG':
+				$type = $this->unmarshalType(
+					$this->walkSimpleArithmeticExpression($aggExpression->pathExpression)
+				);
+
+				if (count($type->getConstantScalarValues()) !== 1) {
+					$type = TypeUtils::generalizeType($type, GeneralizePrecision::lessSpecific());
+				}
+
+				$type = TypeCombinator::union($type, $type->toFloat(), $type->toFloat()->toString());
+
+				return $this->marshalType(TypeCombinator::addNull($type));
+
 			case 'SUM':
 				$type = $this->unmarshalType(
 					$this->walkSimpleArithmeticExpression($aggExpression->pathExpression)
 				);
+
+				$type = TypeUtils::generalizeType($type, GeneralizePrecision::lessSpecific());
 
 				return $this->marshalType(TypeCombinator::addNull($type));
 

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\Tools\SchemaTool;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
-use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantTypeHelper;
@@ -723,10 +722,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				[
 					new ConstantIntegerType(5),
 					TypeCombinator::union(
-						new ConstantStringType('1'),
-						new ConstantIntegerType(1),
-						new ConstantStringType('1.0'),
-						new ConstantFloatType(1.0),
+						$this->intStringified(),
+						new FloatType(),
 						new NullType()
 					),
 				],

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantTypeHelper;
@@ -678,6 +679,84 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 							COUNT(m.intColumn) AS count
 				FROM		QueryResult\Entities\Many m
 				GROUP BY	m.intColumn
+			',
+		];
+
+		yield 'aggregate on literal' => [
+			$this->constantArray([
+				[
+					new ConstantIntegerType(1),
+					TypeCombinator::union(
+						new ConstantStringType('1'),
+						new ConstantIntegerType(1),
+						new NullType()
+					),
+				],
+				[
+					new ConstantIntegerType(2),
+					TypeCombinator::union(
+						new ConstantStringType('0'),
+						new ConstantIntegerType(0),
+						new ConstantStringType('1'),
+						new ConstantIntegerType(1),
+						new NullType()
+					),
+				],
+				[
+					new ConstantIntegerType(3),
+					TypeCombinator::union(
+						new ConstantStringType('1'),
+						new ConstantIntegerType(1),
+						new NullType()
+					),
+				],
+				[
+					new ConstantIntegerType(4),
+					TypeCombinator::union(
+						new ConstantStringType('0'),
+						new ConstantIntegerType(0),
+						new ConstantStringType('1'),
+						new ConstantIntegerType(1),
+						new NullType()
+					),
+				],
+				[
+					new ConstantIntegerType(5),
+					TypeCombinator::union(
+						new ConstantStringType('1'),
+						new ConstantIntegerType(1),
+						new ConstantStringType('1.0'),
+						new ConstantFloatType(1.0),
+						new NullType()
+					),
+				],
+				[
+					new ConstantIntegerType(6),
+					TypeCombinator::union(
+						$this->intStringified(),
+						new FloatType(),
+						new NullType()
+					),
+				],
+				[
+					new ConstantIntegerType(7),
+					TypeCombinator::addNull($this->intStringified()),
+				],
+				[
+					new ConstantIntegerType(8),
+					TypeCombinator::addNull($this->intStringified()),
+				],
+			]),
+			'
+				SELECT		MAX(1),
+							MAX(CASE WHEN m.intColumn = 0 THEN 1 ELSE 0 END),
+							MIN(1),
+							MIN(CASE WHEN m.intColumn = 0 THEN 1 ELSE 0 END),
+							AVG(1),
+							AVG(CASE WHEN m.intColumn = 0 THEN 1 ELSE 0 END),
+							SUM(1),
+							SUM(CASE WHEN m.intColumn = 0 THEN 1 ELSE 0 END)
+				FROM		QueryResult\Entities\Many m
 			',
 		];
 


### PR DESCRIPTION
Closes #460

Since you introduced this in https://github.com/phpstan/phpstan-doctrine/pull/232, I'll be happy to have your review @arnaud-lb 

When doing a SUM, I think the type must be "ungeneralize" (cf #460 )

When doing a AVG,
- if the value is not constant, I think the type must be "ungeneralize" too
- also, I got a failure without `$type = TypeCombinator::union($type, $type->toFloat(), $type->toFloat()->toString());` because the AVG value computed in my tests was `1.0` or `'1.0'` (even for `AVG(1)) and not `1` or `'1'` so I think we need to add the float result (and the stringified float result).