### PR TITLE
Enforce literal string for connection execute methods

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -19,7 +19,12 @@ parameters:
 			- Doctrine\ORM\Tools\Pagination\Paginator
 	stubFiles:
 		- stubs/Criteria.stub
+		- stubs/DBAL/Cache/CacheException.stub
+		- stubs/DBAL/Cache/QueryCacheProfile.stub
 		- stubs/DBAL/Exception/UniqueConstraintViolationException.stub
+		- stubs/DBAL/Types/Type.stub
+		- stubs/DBAL/Exception.stub
+		- stubs/DBAL/Result.stub
 		- stubs/DocumentManager.stub
 		- stubs/DocumentRepository.stub
 		- stubs/EntityManager.stub

--- a/src/Stubs/Doctrine/StubFilesExtensionLoader.php
+++ b/src/Stubs/Doctrine/StubFilesExtensionLoader.php
@@ -35,6 +35,7 @@ class StubFilesExtensionLoader implements StubFilesExtension
 		}
 
 		$files = [
+			$path . '/DBAL/Connection.stub',
 			$path . '/ORM/QueryBuilder.stub',
 			$path . '/EntityRepository.stub',
 		];

--- a/stubs/DBAL/Cache/CacheException.stub
+++ b/stubs/DBAL/Cache/CacheException.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\DBAL\Cache;
+
+use Doctrine\DBAL\Exception;
+
+class CacheException extends Exception
+{
+
+}

--- a/stubs/DBAL/Cache/QueryCacheProfile.stub
+++ b/stubs/DBAL/Cache/QueryCacheProfile.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL\Cache;
+
+class QueryCacheProfile
+{
+
+}

--- a/stubs/DBAL/Connection.stub
+++ b/stubs/DBAL/Connection.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+class Connection
+{
+
+}

--- a/stubs/DBAL/Exception.stub
+++ b/stubs/DBAL/Exception.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+class Exception extends \Exception
+{
+
+}

--- a/stubs/DBAL/Exception/UniqueConstraintViolationException.stub
+++ b/stubs/DBAL/Exception/UniqueConstraintViolationException.stub
@@ -2,7 +2,9 @@
 
 namespace Doctrine\DBAL\Exception;
 
-class UniqueConstraintViolationException extends \Exception
+use Doctrine\DBAL\Exception;
+
+class UniqueConstraintViolationException extends Exception
 {
 
 }

--- a/stubs/DBAL/Result.stub
+++ b/stubs/DBAL/Result.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+class Result
+{
+
+}

--- a/stubs/DBAL/Types/Type.stub
+++ b/stubs/DBAL/Types/Type.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Doctrine\DBAL\Types;
+
+abstract class Type
+{
+}

--- a/stubs/bleedingEdge/DBAL/Connection.stub
+++ b/stubs/bleedingEdge/DBAL/Connection.stub
@@ -1,0 +1,64 @@
+<?php
+
+namespace Doctrine\DBAL;
+
+use Doctrine\DBAL\Cache\CacheException;
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\Types\Type;
+
+class Connection
+{
+    /**
+     * Executes an SQL statement with the given parameters and returns the number of affected rows.
+     *
+     * Could be used for:
+     *  - DML statements: INSERT, UPDATE, DELETE, etc.
+     *  - DDL statements: CREATE, DROP, ALTER, etc.
+     *  - DCL statements: GRANT, REVOKE, etc.
+     *  - Session control statements: ALTER SESSION, SET, DECLARE, etc.
+     *  - Other statements that don't yield a row set.
+     *
+     * This method supports PDO binding types as well as DBAL mapping types.
+     *
+     * @param literal-string                                                       $sql    SQL statement
+     * @param list<mixed>|array<string, mixed>                                     $params Statement parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     *
+     * @return int|string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function executeStatement($sql, array $params = [], array $types = []);
+
+    /**
+     * Executes an, optionally parameterized, SQL query.
+     *
+     * If the query is parametrized, a prepared statement is used.
+     * If an SQLLogger is configured, the execution is logged.
+     *
+     * @param literal-string                                                       $sql    SQL query
+     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     *
+     * @throws Exception
+     */
+    public function executeQuery(
+        string $sql,
+        array $params = [],
+        $types = [],
+        ?QueryCacheProfile $qcp = null
+    ): Result;
+
+    /**
+     * Executes a caching query.
+     *
+     * @param literal-string                                                       $sql    SQL query
+     * @param list<mixed>|array<string, mixed>                                     $params Query parameters
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types  Parameter types
+     *
+     * @throws CacheException
+     * @throws Exception
+     */
+    public function executeCacheQuery($sql, $params, $types, QueryCacheProfile $qcp): Result;
+
+}


### PR DESCRIPTION
In the same way that we enforce passing literal string to QueryBuilder methods in https://github.com/phpstan/phpstan-doctrine/blob/1.4.x/stubs/bleedingEdge/ORM/QueryBuilder.stub

I wonder if we shouldn't enforce literal string to for `Connection::execute*` methods which executes SQL directly.

This would help chaning query like
```
->executeQuery('SELECT foo where foo.bar = '.$nonLiteralValue);
```
to
```
->executeQuery('SELECT foo where foo.bar = :value', ['value' => $nonLiteralValue]);
```