### PR TITLE
Enforce Select queries on Connection::executeQuery

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -63,3 +63,5 @@ services:
 		class: PHPStan\Classes\DoctrineProxyForbiddenClassNamesExtension
 		tags:
 			- phpstan.forbiddenClassNamesExtension
+	-
+		class: PHPStan\Rules\Doctrine\ORM\ExecuteQueryRule

--- a/src/Rules/Doctrine/ORM/ExecuteQueryRule.php
+++ b/src/Rules/Doctrine/ORM/ExecuteQueryRule.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use function count;
+use function sprintf;
+use function str_starts_with;
+use function strtolower;
+use function trim;
+
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+class ExecuteQueryRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\MethodCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Identifier) {
+			return [];
+		}
+
+		if (count($node->getArgs()) === 0) {
+			return [];
+		}
+
+		$methodName = $node->name->toLowerString();
+		if (
+			$methodName !== 'executequery'
+			&& $methodName !== 'executecachequery'
+		) {
+			return [];
+		}
+
+		$calledOnType = $scope->getType($node->var);
+		$connection = 'Doctrine\DBAL\Connection';
+		if (!(new ObjectType($connection))->isSuperTypeOf($calledOnType)->yes()) {
+			return [];
+		}
+
+		$queries = $scope->getType($node->getArgs()[0]->value)->getConstantStrings();
+		if (count($queries) === 0) {
+			return [];
+		}
+
+		foreach ($queries as $query) {
+			if (!$this->isSelectQuery($query->getValue())) {
+				return [
+					RuleErrorBuilder::message(sprintf(
+						'Only SELECT queries are allowed in the method %s. For statements, you must use executeStatement instead.',
+						$node->name->toString()
+					))->identifier('doctrine.query')->build(),
+				];
+			}
+		}
+
+		return [];
+	}
+
+	private function isSelectQuery(string $sql): bool
+	{
+		return str_starts_with(strtolower(trim($sql)), 'select');
+	}
+
+}

--- a/src/Rules/Doctrine/ORM/ExecuteQueryRule.php
+++ b/src/Rules/Doctrine/ORM/ExecuteQueryRule.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 use function count;
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function strtolower;
 use function trim;
@@ -69,7 +70,16 @@ class ExecuteQueryRule implements Rule
 
 	private function isSelectQuery(string $sql): bool
 	{
-		return str_starts_with(strtolower(trim($sql)), 'select');
+		$sql = strtolower(trim($sql));
+
+		// `executeQuery` can be used for returning statements like
+		// `UPDATE ... RETURNING`, so we ignore such case to avoid false positive.
+		// @see https://github.com/phpstan/phpstan-doctrine/issues/545#issuecomment-2015059629
+		if (str_contains($sql, 'returning')) {
+			return true;
+		}
+
+		return str_starts_with($sql, 'select');
 	}
 
 }

--- a/tests/Rules/Doctrine/ORM/ExecuteQueryRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/ExecuteQueryRuleTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExecuteQueryRule>
+ */
+class ExecuteQueryRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ExecuteQueryRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/execute-query.php'], [
+			[
+				'Only SELECT queries are allowed in the method executeQuery. For statements, you must use executeStatement instead.',
+				15,
+			],
+			[
+				'Only SELECT queries are allowed in the method executeQuery. For statements, you must use executeStatement instead.',
+				16,
+			],
+			[
+				'Only SELECT queries are allowed in the method executeCacheQuery. For statements, you must use executeStatement instead.',
+				20,
+			],
+			[
+				'Only SELECT queries are allowed in the method executeCacheQuery. For statements, you must use executeStatement instead.',
+				21,
+			],
+		]);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../../extension.neon',
+			__DIR__ . '/entity-manager.neon',
+		];
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/data/execute-query.php
+++ b/tests/Rules/Doctrine/ORM/data/execute-query.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\Connection;
+
+class TestExecuteQuery
+{
+
+	public function test(Connection $connection, QueryCacheProfile $cacheProfile): void
+	{
+		$connection->executeQuery('SELECT foo from bar WHERE id = 1;');
+		$connection->executeQuery(' SELECT foo from bar WHERE id = 1; ');
+		$connection->executeQuery('UPDATE bar SET foo = NULL WHERE id = 1;');
+		$connection->executeQuery(' UPDATE bar SET foo = NULL WHERE id = 1; ');
+
+		$connection->executeCacheQuery('SELECT foo from bar WHERE id = 1;', [], [], $cacheProfile);
+		$connection->executeCacheQuery(' SELECT foo from bar WHERE id = 1; ', [], [], $cacheProfile);
+		$connection->executeCacheQuery('UPDATE bar SET foo = NULL WHERE id = 1;', [], [], $cacheProfile);
+		$connection->executeCacheQuery(' UPDATE bar SET foo = NULL WHERE id = 1; ', [], [], $cacheProfile);
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/data/execute-query.php
+++ b/tests/Rules/Doctrine/ORM/data/execute-query.php
@@ -19,6 +19,9 @@ class TestExecuteQuery
 		$connection->executeCacheQuery(' SELECT foo from bar WHERE id = 1; ', [], [], $cacheProfile);
 		$connection->executeCacheQuery('UPDATE bar SET foo = NULL WHERE id = 1;', [], [], $cacheProfile);
 		$connection->executeCacheQuery(' UPDATE bar SET foo = NULL WHERE id = 1; ', [], [], $cacheProfile);
+
+		$connection->executeQuery('UPDATE bar SET foo = NULL WHERE id = 1 RETURNING *;');
+		$connection->executeCacheQuery('UPDATE bar SET foo = NULL WHERE id = 1 RETURNING *;', [], [], $cacheProfile);
 	}
 
 }


### PR DESCRIPTION
Related to https://github.com/phpstan/phpstan-doctrine/issues/545

If you're okay adding something like this here, I can do the same rule for executeStatement @ondrejmirtes.