### PR TITLE
Synchronize `Collection::add` with doctrine/collections

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -38,7 +38,6 @@ parameters:
 		- stubs/Persistence/ObjectRepository.stub
 		- stubs/RepositoryFactory.stub
 		- stubs/Collections/ArrayCollection.stub
-		- stubs/Collections/Collection.stub
 		- stubs/Collections/ReadableCollection.stub
 		- stubs/Collections/Selectable.stub
 		- stubs/ORM/AbstractQuery.stub

--- a/src/Stubs/Doctrine/StubFilesExtensionLoader.php
+++ b/src/Stubs/Doctrine/StubFilesExtensionLoader.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Stubs\Doctrine;
 
 use Composer\InstalledVersions;
+use OutOfBoundsException;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\PhpDoc\StubFilesExtension;
+use function class_exists;
 use function dirname;
 use function strpos;
 
@@ -61,9 +63,13 @@ class StubFilesExtensionLoader implements StubFilesExtension
 			$files[] = $stubsDir . '/ServiceEntityRepository.stub';
 		}
 
-		$collectionVersion = class_exists(InstalledVersions::class)
-			? InstalledVersions::getVersion('doctrine/collections')
-			: null;
+		try {
+			$collectionVersion = class_exists(InstalledVersions::class)
+				? InstalledVersions::getVersion('doctrine/collections')
+				: null;
+		} catch (OutOfBoundsException $e) {
+			$collectionVersion = null;
+		}
 		if ($collectionVersion !== null && strpos($collectionVersion, '1.') === 0) {
 			$files[] = $stubsDir . '/Collections/Collection1.stub';
 		} else {

--- a/src/Stubs/Doctrine/StubFilesExtensionLoader.php
+++ b/src/Stubs/Doctrine/StubFilesExtensionLoader.php
@@ -2,10 +2,12 @@
 
 namespace PHPStan\Stubs\Doctrine;
 
+use Composer\InstalledVersions;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\PhpDoc\StubFilesExtension;
 use function dirname;
+use function strpos;
 
 class StubFilesExtensionLoader implements StubFilesExtension
 {
@@ -57,6 +59,13 @@ class StubFilesExtensionLoader implements StubFilesExtension
 			$files[] = $stubsDir . '/LazyServiceEntityRepository.stub';
 		} else {
 			$files[] = $stubsDir . '/ServiceEntityRepository.stub';
+		}
+
+		$collectionVersion = InstalledVersions::getVersion('doctrine/dbal');
+		if ($collectionVersion !== null && strpos($collectionVersion, '1.') === 0) {
+			$files[] = $stubsDir . '/Collections/Collection1.stub';
+		} else {
+			$files[] = $stubsDir . '/Collections/Collection.stub';
 		}
 
 		return $files;

--- a/src/Stubs/Doctrine/StubFilesExtensionLoader.php
+++ b/src/Stubs/Doctrine/StubFilesExtensionLoader.php
@@ -61,7 +61,9 @@ class StubFilesExtensionLoader implements StubFilesExtension
 			$files[] = $stubsDir . '/ServiceEntityRepository.stub';
 		}
 
-		$collectionVersion = InstalledVersions::getVersion('doctrine/dbal');
+		$collectionVersion = class_exists(InstalledVersions::class)
+			? InstalledVersions::getVersion('doctrine/collections')
+			: null;
 		if ($collectionVersion !== null && strpos($collectionVersion, '1.') === 0) {
 			$files[] = $stubsDir . '/Collections/Collection1.stub';
 		} else {

--- a/stubs/Collections/Collection.stub
+++ b/stubs/Collections/Collection.stub
@@ -21,7 +21,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess, Readable
      *
      * @param T $element
      *
-     * @return true
+     * @return void
      */
     public function add($element) {}
 

--- a/stubs/Collections/Collection1.stub
+++ b/stubs/Collections/Collection1.stub
@@ -21,7 +21,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess, Readable
      *
      * @param T $element
      *
-     * @return void
+     * @return true
      */
     public function add($element) {}
 

--- a/stubs/Collections/Collection1.stub
+++ b/stubs/Collections/Collection1.stub
@@ -21,7 +21,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess, Readable
      *
      * @param T $element
      *
-     * @return true
+     * @return void
      */
     public function add($element) {}
 


### PR DESCRIPTION
Hi,

`Collection::add` returns `void` and not `true` according to doctrine/collections
https://github.com/doctrine/collections/blob/9b9c38a3eff3c7477989129b096d21e2b1710ee0/src/Collection.php#L34-L42