### PR TITLE
Fix EntityManagerInterface wrapInTransaction stub

### DIFF
--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -70,7 +70,7 @@ interface EntityManagerInterface extends ObjectManager
 
 	/**
 	 * @param-immediately-invoked-callable $func
-	 * @param callable(): T $func
+	 * @param callable(self): T $func
 	 * @return T
 	 *
 	 * @template T


### PR DESCRIPTION
`wrapInTransaction`'s callable takes `self` as a parameter.