### PR TITLE
Fix wrong coalesce type inference

### DIFF
--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -548,26 +548,18 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 				$this->constantArray([
 					[
 						new ConstantIntegerType(1),
-						TypeCombinator::union(
-							new ConstantStringType('a'),
-							new ConstantStringType('b')
-						),
+						new StringType(),
 					],
 					[
 						new ConstantIntegerType(2),
 						TypeCombinator::union(
-							new ConstantIntegerType(1),
-							new ConstantIntegerType(2),
-							new ConstantStringType('1'),
-							new ConstantStringType('2')
+							$this->numericString(),
+							new IntegerType()
 						),
 					],
 					[
 						new ConstantIntegerType(3),
-						TypeCombinator::union(
-							new ConstantStringType('1'),
-							new ConstantStringType('2')
-						),
+						$this->numericString(),
 					],
 				]),
 				'
@@ -842,11 +834,20 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					new ConstantIntegerType(3),
 					$this->intStringified(),
 				],
+				[
+					new ConstantIntegerType(4),
+					TypeCombinator::union(
+						new IntegerType(),
+						new FloatType(),
+						$this->numericString()
+					),
+				],
 			]),
 			'
 				SELECT		COALESCE(m.stringNullColumn, m.intColumn, false),
 							COALESCE(m.stringNullColumn, m.stringNullColumn),
-							COALESCE(NULLIF(m.intColumn, 1), 0)
+							COALESCE(NULLIF(m.intColumn, 1), 0),
+							COALESCE(1, 1.1)
 				FROM		QueryResult\Entities\Many m
 			',
 		];
@@ -1142,8 +1143,8 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 					[
 						new ConstantIntegerType(2),
 						TypeCombinator::union(
-							new ConstantIntegerType(1),
-							new ConstantStringType('1')
+							new IntegerType(),
+							$this->numericString()
 						),
 					],
 					[


### PR DESCRIPTION
Separated from #506

Coalesce is pretty nasty function: 

- It picks one of the types given in args and tries to cast all the others to that one (if that one comes to play due to nullability of others).
- The logic differs platform by platform  
  - e.g. `COALESCE(1, 'foo')` is `'1'` in MySQL and `1` in SQLite and SQL server
- The casting logic is not documented for MySQL at all.
- SQL server has this documented, but it would be pretty complex to implement it precisely:
  - [https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql?view=sql-server-ver16&redirectedfrom=MSDN#comparing[…]and-isnull](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql?view=sql-server-ver16&redirectedfrom=MSDN#comparing-coalesce-and-isnull)
    - pt 2: "COALESCE returns the data type of value with the highest precedence."
  - https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-type-precedence-transact-sql?view=sql-server-ver16&redirectedfrom=MSDN
    - the precedence list

Therefore, we cannot use the constant types if we do not know the casting logic as it results in wrong types deduced.