### PR TITLE
QueryResultTypeWalker: fix nullability checks over unknown type

### DIFF
--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -376,7 +376,7 @@ class QueryResultTypeWalker extends SqlWalker
 					new FloatType()
 				);
 
-				if (TypeCombinator::containsNull($exprType)) {
+				if ($this->canBeNull($exprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -388,7 +388,7 @@ class QueryResultTypeWalker extends SqlWalker
 				$secondExprType = $this->unmarshalType($function->secondArithmetic->dispatch($this));
 
 				$type = IntegerRangeType::fromInterval(0, null);
-				if (TypeCombinator::containsNull($firstExprType) || TypeCombinator::containsNull($secondExprType)) {
+				if ($this->canBeNull($firstExprType) || $this->canBeNull($secondExprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -399,7 +399,7 @@ class QueryResultTypeWalker extends SqlWalker
 
 				foreach ($function->concatExpressions as $expr) {
 					$type = $this->unmarshalType($expr->dispatch($this));
-					$hasNull = $hasNull || TypeCombinator::containsNull($type);
+					$hasNull = $hasNull || $this->canBeNull($type);
 				}
 
 				$type = new StringType();
@@ -420,7 +420,7 @@ class QueryResultTypeWalker extends SqlWalker
 				$intervalExprType = $this->unmarshalType($function->intervalExpression->dispatch($this));
 
 				$type = new StringType();
-				if (TypeCombinator::containsNull($dateExprType) || TypeCombinator::containsNull($intervalExprType)) {
+				if ($this->canBeNull($dateExprType) || $this->canBeNull($intervalExprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -434,7 +434,7 @@ class QueryResultTypeWalker extends SqlWalker
 					new IntegerType(),
 					new FloatType()
 				);
-				if (TypeCombinator::containsNull($date1ExprType) || TypeCombinator::containsNull($date2ExprType)) {
+				if ($this->canBeNull($date1ExprType) || $this->canBeNull($date2ExprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -444,7 +444,7 @@ class QueryResultTypeWalker extends SqlWalker
 				$stringPrimaryType = $this->unmarshalType($function->stringPrimary->dispatch($this));
 
 				$type = IntegerRangeType::fromInterval(0, null);
-				if (TypeCombinator::containsNull($stringPrimaryType)) {
+				if ($this->canBeNull($stringPrimaryType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -455,7 +455,7 @@ class QueryResultTypeWalker extends SqlWalker
 				$secondExprType = $this->unmarshalType($this->walkStringPrimary($function->secondStringPrimary));
 
 				$type = IntegerRangeType::fromInterval(0, null);
-				if (TypeCombinator::containsNull($firstExprType) || TypeCombinator::containsNull($secondExprType)) {
+				if ($this->canBeNull($firstExprType) || $this->canBeNull($secondExprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -467,7 +467,7 @@ class QueryResultTypeWalker extends SqlWalker
 				$stringPrimaryType = $this->unmarshalType($function->stringPrimary->dispatch($this));
 
 				$type = new StringType();
-				if (TypeCombinator::containsNull($stringPrimaryType)) {
+				if ($this->canBeNull($stringPrimaryType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -478,7 +478,7 @@ class QueryResultTypeWalker extends SqlWalker
 				$secondExprType = $this->unmarshalType($this->walkSimpleArithmeticExpression($function->secondSimpleArithmeticExpression));
 
 				$type = IntegerRangeType::fromInterval(0, null);
-				if (TypeCombinator::containsNull($firstExprType) || TypeCombinator::containsNull($secondExprType)) {
+				if ($this->canBeNull($firstExprType) || $this->canBeNull($secondExprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -493,7 +493,7 @@ class QueryResultTypeWalker extends SqlWalker
 				$exprType = $this->unmarshalType($this->walkSimpleArithmeticExpression($function->simpleArithmeticExpression));
 
 				$type = new FloatType();
-				if (TypeCombinator::containsNull($exprType)) {
+				if ($this->canBeNull($exprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -510,7 +510,7 @@ class QueryResultTypeWalker extends SqlWalker
 				}
 
 				$type = new StringType();
-				if (TypeCombinator::containsNull($stringType) || TypeCombinator::containsNull($firstExprType) || TypeCombinator::containsNull($secondExprType)) {
+				if ($this->canBeNull($stringType) || $this->canBeNull($firstExprType) || $this->canBeNull($secondExprType)) {
 					$type = TypeCombinator::addNull($type);
 				}
 
@@ -714,7 +714,7 @@ class QueryResultTypeWalker extends SqlWalker
 			}
 
 			$type = $this->unmarshalType($expression->dispatch($this));
-			$allTypesContainNull = $allTypesContainNull && TypeCombinator::containsNull($type);
+			$allTypesContainNull = $allTypesContainNull && $this->canBeNull($type);
 
 			// Some drivers manipulate the types, lets avoid false positives by generalizing constant types
 			// e.g. sqlsrv: "COALESCE returns the data type of value with the highest precedence"

--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerTest.php
@@ -7,6 +7,7 @@ use Composer\Semver\VersionParser;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Type as DbalType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -44,6 +45,7 @@ use QueryResult\EntitiesEnum\EntityWithEnum;
 use QueryResult\EntitiesEnum\IntEnum;
 use QueryResult\EntitiesEnum\StringEnum;
 use Throwable;
+use Type\Doctrine\data\QueryResult\CustomIntType;
 use function array_merge;
 use function array_shift;
 use function assert;
@@ -75,6 +77,10 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 	{
 		$em = require __DIR__ . '/../data/QueryResult/entity-manager.php';
 		self::$em = $em;
+
+		if (!DbalType::hasType(CustomIntType::NAME)) {
+			DbalType::addType(CustomIntType::NAME, CustomIntType::class);
+		}
 
 		$schemaTool = new SchemaTool($em);
 		$classes = $em->getMetadataFactory()->getAllMetadata();
@@ -1238,6 +1244,16 @@ final class QueryResultTypeWalkerTest extends PHPStanTestCase
 							ABS(1),
 							ABS(\'foo\')
 				FROM		QueryResult\Entities\Many m
+			',
+		];
+
+		yield 'abs function with mixed' => [
+			$this->constantArray([
+				[new ConstantIntegerType(1), TypeCombinator::addNull($this->unumericStringified())],
+			]),
+			'
+				SELECT		ABS(o.mixedColumn)
+				FROM		QueryResult\Entities\One o
 			',
 		];
 

--- a/tests/Type/Doctrine/data/QueryResult/CustomIntType.php
+++ b/tests/Type/Doctrine/data/QueryResult/CustomIntType.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Type\Doctrine\data\QueryResult;
+
+use Doctrine\DBAL\Types\IntegerType;
+
+class CustomIntType extends IntegerType
+{
+
+	public const NAME = 'custom_int';
+
+	public function getName(): string
+	{
+		return self::NAME;
+	}
+
+}

--- a/tests/Type/Doctrine/data/QueryResult/Entities/One.php
+++ b/tests/Type/Doctrine/data/QueryResult/Entities/One.php
@@ -74,6 +74,13 @@ class One
 	 */
 	public $embedded;
 
+	/**
+	 * @Column(type="custom_int", nullable=true)
+	 *
+	 * @var mixed
+	 */
+	public $mixedColumn;
+
 	public function __construct()
 	{
 		$this->subOne = new SubOne();


### PR DESCRIPTION
Separated from https://github.com/phpstan/phpstan-doctrine/pull/506

Without this fix, the new testcase fails to add nullability and the inferred type does not accept the real result (invalid type was inferred). More `mixed` tests with all possible AST nodes is in the origin PR.