### PR TITLE
Do not infer getArrayResult for now

### DIFF
--- a/tests/Type/Doctrine/Query/QueryResultTypeWalkerHydrationModeTest.php
+++ b/tests/Type/Doctrine/Query/QueryResultTypeWalkerHydrationModeTest.php
@@ -138,42 +138,6 @@ final class QueryResultTypeWalkerHydrationModeTest extends PHPStanTestCase
 			Query::HYDRATE_SIMPLEOBJECT,
 		];
 
-		yield 'getResult(array), full entity' => [
-			new MixedType(),
-			'
-				SELECT		s
-				FROM		QueryResult\Entities\Simple s
-			',
-			'getResult',
-			Query::HYDRATE_ARRAY,
-		];
-
-		yield 'getResult(array), fields' => [
-			self::list(self::constantArray([
-				[new ConstantStringType('decimalColumn'), self::numericString()],
-				[new ConstantStringType('floatColumn'), new FloatType()],
-			])),
-			'
-				SELECT		s.decimalColumn, s.floatColumn
-				FROM		QueryResult\Entities\Simple s
-			',
-			'getResult',
-			Query::HYDRATE_ARRAY,
-		];
-
-		yield 'getResult(array), expressions' => [
-			self::list(self::constantArray([
-				[new ConstantStringType('decimalColumn'), self::floatOrIntOrStringified()],
-				[new ConstantStringType('floatColumn'), self::floatOrStringified()],
-			])),
-			'
-				SELECT		-s.decimalColumn as decimalColumn, -s.floatColumn as floatColumn
-				FROM		QueryResult\Entities\Simple s
-			',
-			'getResult',
-			Query::HYDRATE_ARRAY,
-		];
-
 		yield 'getResult(object), fields' => [
 			self::list(self::constantArray([
 				[new ConstantStringType('decimalColumn'), self::numericString()],
@@ -246,44 +210,10 @@ final class QueryResultTypeWalkerHydrationModeTest extends PHPStanTestCase
 			Query::HYDRATE_SIMPLEOBJECT,
 		];
 
-		yield 'toIterable(array), full entity' => [
-			new MixedType(),
-			'
-				SELECT		s
-				FROM		QueryResult\Entities\Simple s
-			',
-			'toIterable',
-			Query::HYDRATE_ARRAY,
-		];
-
 		yield 'getArrayResult(), full entity' => [
 			new MixedType(),
 			'
 				SELECT		s
-				FROM		QueryResult\Entities\Simple s
-			',
-			'getArrayResult',
-		];
-
-		yield 'getArrayResult(), fields' => [
-			self::list(self::constantArray([
-				[new ConstantStringType('decimalColumn'), self::numericString()],
-				[new ConstantStringType('floatColumn'), new FloatType()],
-			])),
-			'
-				SELECT		s.decimalColumn, s.floatColumn
-				FROM		QueryResult\Entities\Simple s
-			',
-			'getArrayResult',
-		];
-
-		yield 'getArrayResult(), expressions' => [
-			self::list(self::constantArray([
-				[new ConstantStringType('decimalColumn'), self::floatOrIntOrStringified()],
-				[new ConstantStringType('floatColumn'), self::floatOrStringified()],
-			])),
-			'
-				SELECT		-s.decimalColumn as decimalColumn, -s.floatColumn as floatColumn
 				FROM		QueryResult\Entities\Simple s
 			',
 			'getArrayResult',

--- a/tests/Type/Doctrine/data/QueryResult/queryResult.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryResult.php
@@ -188,41 +188,6 @@ class QueryResultTest
 			'mixed',
 			$query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)
 		);
-
-
-		$query = $em->createQuery('
-			SELECT		m.intColumn, m.stringNullColumn, m.datetimeColumn
-			FROM		QueryResult\Entities\Many m
-		');
-
-		assertType(
-			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
-			$query->getResult(AbstractQuery::HYDRATE_ARRAY)
-		);
-		assertType(
-			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
-			$query->getArrayResult()
-		);
-		assertType(
-			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
-			$query->execute(null, AbstractQuery::HYDRATE_ARRAY)
-		);
-		assertType(
-			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
-			$query->executeIgnoreQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
-		);
-		assertType(
-			'list<array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}>',
-			$query->executeUsingQueryCache(null, AbstractQuery::HYDRATE_ARRAY)
-		);
-		assertType(
-			'array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}',
-			$query->getSingleResult(AbstractQuery::HYDRATE_ARRAY)
-		);
-		assertType(
-			'array{intColumn: int, stringNullColumn: string|null, datetimeColumn: DateTime}|null',
-			$query->getOneOrNullResult(AbstractQuery::HYDRATE_ARRAY)
-		);
 	}
 
 


### PR DESCRIPTION
/cc @VincentLanglet With @janedbal we decided not to release this alongside the huge changes from https://github.com/phpstan/phpstan-doctrine/pull/506.

I'm worried about the impact of #506 and I want to minize it. There's nothing wrong with your PR but it surfaces some issues we should solve first (and that are already present in object hydration to be fair).

I'd love if we could make phpstan-doctrine understand that `where`/`andWhere` can make a selected field non-nullable for example.