### PR TITLE
Fix subselect aggregate functions

### DIFF
--- a/src/Type/Doctrine/Query/QueryAggregateFunctionDetectorTreeWalker.php
+++ b/src/Type/Doctrine/Query/QueryAggregateFunctionDetectorTreeWalker.php
@@ -25,6 +25,10 @@ class QueryAggregateFunctionDetectorTreeWalker extends Query\TreeWalkerAdapter
 			return;
 		}
 
+		if ($node instanceof AST\Subselect) {
+			return;
+		}
+
 		if ($this->isAggregateFunction($node)) {
 			$this->markAggregateFunctionFound();
 			return;

--- a/tests/Platform/QueryResultTypeWalkerFetchTypeMatrixTest.php
+++ b/tests/Platform/QueryResultTypeWalkerFetchTypeMatrixTest.php
@@ -3833,6 +3833,22 @@ final class QueryResultTypeWalkerFetchTypeMatrixTest extends PHPStanTestCase
 			'stringify' => self::STRINGIFY_NONE,
 		];
 
+		yield 'SUBSELECT' => [
+			'data' => self::dataDefault(),
+			'select' => 'SELECT t1.col_int, (SELECT COUNT(t2.col_int) FROM ' . PlatformEntity::class . ' t2) FROM %s t1',
+			'mysql' => self::int(),
+			'sqlite' => self::int(),
+			'pdo_pgsql' => self::int(),
+			'pgsql' => self::int(),
+			'mssql' => self::int(),
+			'mysqlResult' => 9,
+			'sqliteResult' => 9,
+			'pdoPgsqlResult' => 9,
+			'pgsqlResult' => 9,
+			'mssqlResult' => 9,
+			'stringify' => self::STRINGIFY_NONE,
+		];
+
 		yield 'COUNT(t.col_int)' => [
 			'data' => self::dataDefault(),
 			'select' => 'SELECT COUNT(t.col_int) FROM %s t',


### PR DESCRIPTION
/cc @janedbal 

[6339dff](https://github.com/phpstan/phpstan-doctrine/commit/6339dffef7c3168ebf705b7737e0022d0038d78f) caused PHPStan to think several of my queries with subselects should be nullable:

SELECT t1.col_int, (SELECT COUNT(t2.col_int) FROM Entity t2) FROM Entity t1

This used to return [int, mixed] but now returns [int|null, mixed].

Writing PHPStan code is fairly new to me, but I've attempted to fix this by not checking subselects. I've also added a test that fails before the change and succeeds after.