### PR TITLE
EntityRepository::count() returns positive int

### DIFF
--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -71,4 +71,11 @@ class EntityRepository implements ObjectRepository
 	 */
 	public function createQueryBuilder($alias, $indexBy = null);
 
+	/**
+	 * @param array<string, mixed> $criteria
+	 *
+	 * @return int<0, max>
+	 */
+	public function count(array $criteria);
+
 }


### PR DESCRIPTION
Fixes #603

The method signature changed slightly between v2 and v3:

https://github.com/doctrine/orm/blob/2.17.x/lib/Doctrine/ORM/EntityRepository.php#L253
https://github.com/doctrine/orm/blob/3.2.x/src/EntityRepository.php#L131

How to handle that? The original code also mentions a `psalm-param`, see
https://github.com/doctrine/orm/blob/2.17.x/lib/Doctrine/ORM/EntityRepository.php#L247