### PR TITLE
Add api annotation to ObjectMetadataResolver::getClassMetadata

### DIFF
--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -106,6 +106,8 @@ final class ObjectMetadataResolver
 	}
 
 	/**
+	 * @api
+	 *
 	 * @template T of object
 	 * @param class-string<T> $className
 	 * @return ClassMetadata<T>|null


### PR DESCRIPTION
Solve https://github.com/phpstan/phpstan/discussions/11975

Since this method is used a lot in phpstan-doctrine rules, it should be allowed for developer to implements customs rule with it too.