### PR TITLE
Add api annotation to ObjectMetadataResolver constructor

### DIFF
--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -29,6 +29,7 @@ final class ObjectMetadataResolver
 	/** @var string */
 	private $tmpDir;
 
+	/** @api */
 	public function __construct(
 		?string $objectManagerLoader,
 		string $tmpDir


### PR DESCRIPTION
This allows to write tests for rules using ObjectMetadataResolver, like the following one
https://github.com/phpstan/phpstan-doctrine/blob/2.0.x/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleTest.php#L17