### PR TITLE
Ignore errors while loading ObjectManager

### DIFF
--- a/src/Doctrine/DoctrineDiagnoseExtension.php
+++ b/src/Doctrine/DoctrineDiagnoseExtension.php
@@ -30,12 +30,22 @@ class DoctrineDiagnoseExtension implements DiagnoseExtension
 
 	public function print(Output $output): void
 	{
+		$objectManager = $this->objectMetadataResolver->getObjectManager();
+
 		$output->writeLineFormatted(sprintf(
 			'<info>Doctrine\'s objectManagerLoader:</info> %s',
 			$this->objectMetadataResolver->hasObjectManagerLoader() ? 'In use' : 'No',
 		));
 
-		$objectManager = $this->objectMetadataResolver->getObjectManager();
+		if ($this->objectMetadataResolver->getLastError() !== null) {
+			$output->writeLineFormatted(sprintf(
+				'<error>Doctrine\'s objectManagerLoader error:</error> %s',
+				$this->objectMetadataResolver->getLastError()->getMessage(),
+			));
+
+			$output->writeLineFormatted('');
+		}
+
 		if ($objectManager instanceof EntityManagerInterface) {
 			$connection = $objectManager->getConnection();
 			$driver = $this->driverDetector->detect($connection);

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -9,6 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 use PHPStan\Doctrine\Mapping\ClassMetadataFactory;
 use PHPStan\ShouldNotHappenException;
 use ReflectionException;
+use Throwable;
 use function class_exists;
 use function is_file;
 use function is_readable;
@@ -25,6 +26,8 @@ final class ObjectMetadataResolver
 	private ?ClassMetadataFactory $metadataFactory = null;
 
 	private string $tmpDir;
+
+	private ?Throwable $lastError = null;
 
 	public function __construct(
 		?string $objectManagerLoader,
@@ -87,6 +90,11 @@ final class ObjectMetadataResolver
 		} catch (ReflectionException $e) {
 			return true;
 		}
+	}
+
+	public function getLastError(): ?Throwable
+	{
+		return $this->lastError;
 	}
 
 	private function getMetadataFactory(): ?ClassMetadataFactory
@@ -160,7 +168,13 @@ final class ObjectMetadataResolver
 			));
 		}
 
-		return require $objectManagerLoader;
+		try {
+			return require $objectManagerLoader;
+		} catch (Throwable $error) {
+			$this->lastError = $error;
+
+			return null;
+		}
 	}
 
 }


### PR DESCRIPTION
It's possible to configure a `objectManagerLoader` that returns an instance to your configured Doctrine manager.

This works great, and it gives PHPStan super capabilities.

In most cases, you would fetch this object manager from the container from your framework (e.g. Symfony).

But that requires the Symfony container to be compiled and booted.

All good, unless you make a typo in one of your service configurations.

You're left with an internal error when running PHPStan:
```

<unknown location> Internal error: You have requested a non-existent service "some_service".
while analysing file /Volumes/CS/www/src/SomeFile.php

Run PHPStan with -v option and post the stack trace to:
https://github.com/phpstan/phpstan/issues/new?template=Bug_report.yaml

Found 1 error

⚠️  Result is incomplete because of severe errors. ⚠️
   Fix these errors first and then re-run PHPStan
   to get all reported errors.

```

Making mistakes is a common thing we do, so having PHPStan crash like this is counter productive.

Even worse, when using the PHPStan integration in PHPStorm, you get error popups every time that this happened.

Since the `objectManagerLoader` is already optional, we can improve things by catching Throwable's that occur while
including the `objectManagerLoader` file and then we return `null`.

To make it easier to debug this problem later, in the diagnostic extension, we show the last error that occurred.