### PR TITLE
fix: update template annotations to remove covariant keyword

### DIFF
--- a/stubs/MongoClassMetadataInfo.stub
+++ b/stubs/MongoClassMetadataInfo.stub
@@ -6,7 +6,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata as BaseClassMetadata;
 use ReflectionClass;
 
 /**
- * @template-covariant T of object
+ * @template T of object
  * @template-implements BaseClassMetadata<T>
  */
 class ClassMetadata implements BaseClassMetadata

--- a/stubs/ORM/Mapping/ClassMetadata.stub
+++ b/stubs/ORM/Mapping/ClassMetadata.stub
@@ -3,7 +3,7 @@
 namespace Doctrine\ORM\Mapping;
 
 /**
- * @template-covariant T of object
+ * @template T of object
  * @extends ClassMetadataInfo<T>
  * @phpstan-type FieldMapping = array{
  *      type: string,

--- a/stubs/ORM/Mapping/ClassMetadataInfo.stub
+++ b/stubs/ORM/Mapping/ClassMetadataInfo.stub
@@ -7,7 +7,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use ReflectionClass;
 
 /**
- * @template-covariant T of object
+ * @template T of object
  * @template-implements ClassMetadata<T>
  * @phpstan-import-type AssociationMapping from \Doctrine\ORM\Mapping\ClassMetadata
  * @phpstan-import-type FieldMapping from \Doctrine\ORM\Mapping\ClassMetadata

--- a/stubs/Persistence/Mapping/ClassMetadata.stub
+++ b/stubs/Persistence/Mapping/ClassMetadata.stub
@@ -5,7 +5,7 @@ namespace Doctrine\Persistence\Mapping;
 use ReflectionClass;
 
 /**
- * @template-covariant T of object
+ * @template T of object
  */
 interface ClassMetadata
 {


### PR DESCRIPTION
## Description

This PR addresses PHPStan errors related to template type variance in Doctrine's metadata classes. The errors were occurring because the template type `T` was declared as covariant but was being used in an invariant position in the `getReflectionClass()` method.

### The Problem

The following errors were reported by PHPStan:

- Template type T is declared as covariant, but occurs in invariant position in return type of method `Doctrine\ODM\MongoDB\Mapping\ClassMetadata::getReflectionClass()`
- Template type T is declared as covariant, but occurs in invariant position in return type of method `Doctrine\ORM\Mapping\ClassMetadataInfo::getReflectionClass()`
- Template type T is declared as covariant, but occurs in invariant position in return type of method `Doctrine\Persistence\Mapping\ClassMetadata::getReflectionClass()`

### The Solution

We removed the `-covariant` modifier from the template type declarations in:
- `MongoClassMetadataInfo.stub`
- `ORM/Mapping/ClassMetadata.stub`
- `ORM/Mapping/ClassMetadataInfo.stub`
- `Persistence/Mapping/ClassMetadata.stub`

### Why This Works

The covariance modifier was inappropriate in this case because:
1. The `getReflectionClass()` method returns a `ReflectionClass<T>`
2. This return type must be exactly of the specified type, not a subtype or supertype
3. When a type parameter is used in an invariant position (like a return type), it should not be declared as covariant

## Issues
#646