### PR TITLE
PlatformTest: drop MSSQL database asserts

### DIFF
--- a/.github/workflows/platform-test.yml
+++ b/.github/workflows/platform-test.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       MYSQL_HOST: '127.0.0.1'
       PGSQL_HOST: '127.0.0.1'
-      MSSQL_HOST: '127.0.0.1'
 
     strategy:
       fail-fast: false
@@ -83,12 +82,3 @@ jobs:
           MYSQL_DATABASE: foo
         ports:
           - "3306:3306"
-
-      mssql:
-        image: mcr.microsoft.com/mssql/server:latest
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: 'Secret.123'
-          MSSQL_PID: Developer
-        ports:
-          - 1433:1433

--- a/tests/Platform/QueryResultTypeWalkerFetchTypeMatrixTest.php
+++ b/tests/Platform/QueryResultTypeWalkerFetchTypeMatrixTest.php
@@ -552,46 +552,6 @@ final class QueryResultTypeWalkerFetchTypeMatrixTest extends PHPStanTestCase
 	 *
 	 * @dataProvider provideCases
 	 */
-	public function testUnsupportedDriver(
-		array $data,
-		string $dqlTemplate,
-		Type $mysqlExpectedType,
-		?Type $sqliteExpectedType,
-		?Type $pdoPgsqlExpectedType,
-		?Type $pgsqlExpectedType,
-		?Type $mssqlExpectedType,
-		$mysqlExpectedResult,
-		$sqliteExpectedResult,
-		$pdoPgsqlExpectedResult,
-		$pgsqlExpectedResult,
-		$mssqlExpectedResult,
-		string $stringify
-	): void
-	{
-		$this->performDriverTest(
-			'sqlsrv',
-			self::CONFIG_DEFAULT,
-			$data,
-			$dqlTemplate,
-			(string) $this->dataName(),
-			PHP_VERSION_ID,
-			$mssqlExpectedType,
-			$mssqlExpectedResult,
-			$stringify,
-		);
-	}
-
-	/**
-	 * @param array<string, mixed> $data
-	 * @param mixed $mysqlExpectedResult
-	 * @param mixed $sqliteExpectedResult
-	 * @param mixed $pdoPgsqlExpectedResult
-	 * @param mixed $pgsqlExpectedResult
-	 * @param mixed $mssqlExpectedResult
-	 * @param self::STRINGIFY_* $stringify
-	 *
-	 * @dataProvider provideCases
-	 */
 	public function testUnknownDriver(
 		array $data,
 		string $dqlTemplate,

--- a/tests/Platform/docker/Dockerfile80
+++ b/tests/Platform/docker/Dockerfile80
@@ -1,17 +1,5 @@
 FROM php:8.0-cli
 
-# MSSQL
-RUN apt update  \
-    && apt install -y gnupg2 \
-    && apt install -y unixodbc-dev unixodbc \
-    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
-    && apt update \
-    && ACCEPT_EULA=Y apt install -y msodbcsql17 \
-    && pecl install sqlsrv-5.11.1 \
-    && pecl install pdo_sqlsrv-5.11.1 \
-    && docker-php-ext-enable sqlsrv pdo_sqlsrv
-
 COPY ./docker-setup.sh /opt/src/scripts/setup.sh
 RUN /opt/src/scripts/setup.sh
 

--- a/tests/Platform/docker/Dockerfile81
+++ b/tests/Platform/docker/Dockerfile81
@@ -1,17 +1,5 @@
 FROM php:8.1-cli
 
-# MSSQL
-RUN apt update  \
-    && apt install -y gnupg2 \
-    && apt install -y unixodbc-dev unixodbc \
-    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
-    && apt update \
-    && ACCEPT_EULA=Y apt install -y msodbcsql17 \
-    && pecl install sqlsrv \
-    && pecl install pdo_sqlsrv \
-    && docker-php-ext-enable sqlsrv pdo_sqlsrv
-
 COPY ./docker-setup.sh /opt/src/scripts/setup.sh
 RUN /opt/src/scripts/setup.sh
 

--- a/tests/Platform/docker/Dockerfile84
+++ b/tests/Platform/docker/Dockerfile84
@@ -1,17 +1,5 @@
 FROM php:8.4-cli
 
-# MSSQL
-RUN apt update  \
-    && apt install -y gnupg2 \
-    && apt install -y unixodbc-dev unixodbc \
-    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/mssql-tools.list \
-    && apt update \
-    && ACCEPT_EULA=Y apt install -y msodbcsql17 \
-    && pecl install sqlsrv \
-    && pecl install pdo_sqlsrv \
-    && docker-php-ext-enable sqlsrv pdo_sqlsrv
-
 COPY ./docker-setup.sh /opt/src/scripts/setup.sh
 RUN /opt/src/scripts/setup.sh
 

--- a/tests/Platform/docker/docker-compose.yml
+++ b/tests/Platform/docker/docker-compose.yml
@@ -27,24 +27,14 @@ services:
                 type: tmpfs
                 target: /var/lib/postgresql/data
 
-    mssql:
-        image: mcr.microsoft.com/mssql/server:latest
-        environment:
-            ACCEPT_EULA: Y
-            SA_PASSWORD: 'Secret.123'
-            MSSQL_PID: Developer
-        ports:
-            - 1433:1433
-
     php80:
-        depends_on: [mysql, pgsql, mssql]
+        depends_on: [mysql, pgsql]
         build:
             context: .
             dockerfile: ./Dockerfile80
         environment:
             MYSQL_HOST: mysql
             PGSQL_HOST: pgsql
-            MSSQL_HOST: mssql
         working_dir: /app
         user: ${UID:-1000}:${GID:-1000}
         volumes:
@@ -58,7 +48,6 @@ services:
         environment:
             MYSQL_HOST: mysql
             PGSQL_HOST: pgsql
-            MSSQL_HOST: mssql
         working_dir: /app
         user: ${UID:-1000}:${GID:-1000}
         volumes:
@@ -72,7 +61,6 @@ services:
         environment:
             MYSQL_HOST: mysql
             PGSQL_HOST: pgsql
-            MSSQL_HOST: mssql
         working_dir: /app
         user: ${UID:-1000}:${GID:-1000}
         volumes:

--- a/tests/Platform/docker/docker-setup.sh
+++ b/tests/Platform/docker/docker-setup.sh
@@ -2,7 +2,7 @@
 set -ex \
   && apt update \
   && apt install -y bash zip libpq-dev libsqlite3-dev \
-  && pecl install xdebug mongodb \
+  && pecl install xdebug mongodb-1.19.4 \
   && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
   && docker-php-ext-install pdo mysqli pgsql pdo_mysql pdo_pgsql pdo_sqlite \
   && docker-php-ext-enable xdebug mongodb


### PR DESCRIPTION
- Closes #657
- Since we still have `testUnknownDriver` test, we are not losing anything by this
  - This was there more-less prepared for easier implementation of sqlsrv support (currently not supported)