### PR TITLE
Invalid mapping type to property type check for binary mapping since DBAL v.4

### DIFF
--- a/tests/Rules/Doctrine/ORM/data/MyEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/MyEntity.php
@@ -83,4 +83,10 @@ class MyEntity
 	 * @ORM\Column(type="json")
 	 */
 	private $jsonString;
+
+	/**
+	 * @var string
+	 * @ORM\Column(type="binary")
+	 */
+	private $binaryString;
 }


### PR DESCRIPTION
This PR demonstrates the bug described in #659 