### PR TITLE
Invalid nullable property check for simple_array mapping type

### DIFF
--- a/tests/Rules/Doctrine/ORM/data/MyEntity.php
+++ b/tests/Rules/Doctrine/ORM/data/MyEntity.php
@@ -83,4 +83,10 @@ class MyEntity
 	 * @ORM\Column(type="json")
 	 */
 	private $jsonString;
+
+	/**
+	 * @var list<string>
+	 * @ORM\Column(type="simple_array", nullable=true)
+	 */
+	private $simpleArrayFromNullableField;
 }


### PR DESCRIPTION
This PR demonstrates the bug described in #670 