### PR TITLE
Check field names of orderBy parameter in findBy and findOneBy

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -47,6 +47,12 @@ services:
 		tags:
 			- phpstan.rules.rule
 	-
+		class: PHPStan\Rules\Doctrine\ORM\RepositoryMethodCallRule
+		arguments:
+			checkOrderByFields: %featureToggles.bleedingEdge%
+		tags:
+			- phpstan.rules.rule
+	-
 		class: PHPStan\Classes\DoctrineProxyForbiddenClassNamesExtension
 		tags:
 			- phpstan.forbiddenClassNamesExtension

--- a/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
@@ -21,9 +21,15 @@ class RepositoryMethodCallRule implements Rule
 
 	private ObjectMetadataResolver $objectMetadataResolver;
 
-	public function __construct(ObjectMetadataResolver $objectMetadataResolver)
+	private bool $checkOrderByFields;
+
+	public function __construct(
+		ObjectMetadataResolver $objectMetadataResolver,
+		bool $checkOrderByFields = false
+	)
 	{
 		$this->objectMetadataResolver = $objectMetadataResolver;
+		$this->checkOrderByFields = $checkOrderByFields;
 	}
 
 	public function getNodeType(): string
@@ -87,33 +93,40 @@ class RepositoryMethodCallRule implements Rule
 			}
 		}
 
+		if (!$this->checkOrderByFields) {
+			return $messages;
+		}
+
+		if (!in_array($methodName, [
+			'findBy',
+			'findOneBy',
+		], true)) {
+			return $messages;
+		}
+
 		$orderByType = count($node->getArgs()) > 1 ? $scope->getType($node->getArgs()[1]->value) : null;
 
-		if (
-			in_array($methodName, [
-				'findBy',
-				'findOneBy',
-			], true)
-			&& $orderByType !== null
-		) {
-			foreach ($orderByType->getConstantArrays() as $constantArray) {
-				foreach ($constantArray->getKeyTypes() as $keyType) {
-					foreach ($keyType->getConstantStrings() as $fieldName) {
-						if (
-							$classMetadata->hasField($fieldName->getValue())
-							|| $classMetadata->hasAssociation($fieldName->getValue())
-						) {
-							continue;
-						}
+		if ($orderByType === null) {
+			return $messages;
+		}
 
-						$messages[] = RuleErrorBuilder::message(sprintf(
-							'Call to method %s::%s() - entity %s does not have a field named $%s.',
-							$calledOnType->describe(VerbosityLevel::typeOnly()),
-							$methodName,
-							$entityClassNames[0],
-							$fieldName->getValue(),
-						))->identifier(sprintf('doctrine.%sArgument', $methodName))->build();
+		foreach ($orderByType->getConstantArrays() as $constantArray) {
+			foreach ($constantArray->getKeyTypes() as $keyType) {
+				foreach ($keyType->getConstantStrings() as $fieldName) {
+					if (
+						$classMetadata->hasField($fieldName->getValue())
+						|| $classMetadata->hasAssociation($fieldName->getValue())
+					) {
+						continue;
 					}
+
+					$messages[] = RuleErrorBuilder::message(sprintf(
+						'Call to method %s::%s() - entity %s does not have a field named $%s.',
+						$calledOnType->describe(VerbosityLevel::typeOnly()),
+						$methodName,
+						$entityClassNames[0],
+						$fieldName->getValue(),
+					))->identifier(sprintf('doctrine.%sArgument', $methodName))->build();
 				}
 			}
 		}

--- a/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
@@ -87,6 +87,37 @@ class RepositoryMethodCallRule implements Rule
 			}
 		}
 
+		$orderByType = count($node->getArgs()) > 1 ? $scope->getType($node->getArgs()[1]->value) : null;
+
+		if (
+			in_array($methodName, [
+				'findBy',
+				'findOneBy',
+			], true)
+			&& $orderByType !== null
+		) {
+			foreach ($orderByType->getConstantArrays() as $constantArray) {
+				foreach ($constantArray->getKeyTypes() as $keyType) {
+					foreach ($keyType->getConstantStrings() as $fieldName) {
+						if (
+							$classMetadata->hasField($fieldName->getValue())
+							|| $classMetadata->hasAssociation($fieldName->getValue())
+						) {
+							continue;
+						}
+
+						$messages[] = RuleErrorBuilder::message(sprintf(
+							'Call to method %s::%s() - entity %s does not have a field named $%s.',
+							$calledOnType->describe(VerbosityLevel::typeOnly()),
+							$methodName,
+							$entityClassNames[0],
+							$fieldName->getValue(),
+						))->identifier(sprintf('doctrine.%sArgument', $methodName))->build();
+					}
+				}
+			}
+		}
+
 		return $messages;
 	}
 

--- a/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-0.json
+++ b/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-0.json
@@ -5,6 +5,16 @@
         "ignorable": true
     },
     {
+        "message": "Call to method Doctrine\\ORM\\EntityRepository<PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity>::findOneBy() - entity PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity does not have a field named $blah.",
+        "line": 94,
+        "ignorable": true
+    },
+    {
+        "message": "Call to method Doctrine\\ORM\\EntityRepository<PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity>::findBy() - entity PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity does not have a field named $blah.",
+        "line": 116,
+        "ignorable": true
+    },
+    {
         "message": "Call to method Doctrine\\ORM\\EntityRepository<PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity>::findBy() - entity PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity does not have a field named $blah.",
         "line": 116,
         "ignorable": true

--- a/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleTest.php
@@ -76,6 +76,38 @@ class RepositoryMethodCallRuleTest extends RuleTestCase
 				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::count() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
 				45,
 			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				54,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				55,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				56,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				56,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				64,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				65,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				66,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				66,
+			],
 		]);
 	}
 

--- a/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleTest.php
@@ -14,7 +14,7 @@ class RepositoryMethodCallRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new RepositoryMethodCallRule(new ObjectMetadataResolver(__DIR__ . '/entity-manager.php', __DIR__ . '/../../../../tmp'));
+		return new RepositoryMethodCallRule(new ObjectMetadataResolver(__DIR__ . '/entity-manager.php', __DIR__ . '/../../../../tmp'), true);
 	}
 
 	/**

--- a/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleWithoutObjectManagerLoaderTest.php
+++ b/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleWithoutObjectManagerLoaderTest.php
@@ -14,7 +14,7 @@ class RepositoryMethodCallRuleWithoutObjectManagerLoaderTest extends RuleTestCas
 
 	protected function getRule(): Rule
 	{
-		return new RepositoryMethodCallRule(new ObjectMetadataResolver(null, __DIR__ . '/../../../../tmp'));
+		return new RepositoryMethodCallRule(new ObjectMetadataResolver(null, __DIR__ . '/../../../../tmp'), true);
 	}
 
 	/**

--- a/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleWithoutObjectManagerLoaderTest.php
+++ b/tests/Rules/Doctrine/ORM/RepositoryMethodCallRuleWithoutObjectManagerLoaderTest.php
@@ -76,6 +76,38 @@ class RepositoryMethodCallRuleWithoutObjectManagerLoaderTest extends RuleTestCas
 				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::count() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
 				45,
 			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				54,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				55,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				56,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				56,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				64,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				65,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $nonexistent.',
+				66,
+			],
+			[
+				'Call to method Doctrine\ORM\EntityRepository<PHPStan\Rules\Doctrine\ORM\MyEntity>::findOneBy() - entity PHPStan\Rules\Doctrine\ORM\MyEntity does not have a field named $transient.',
+				66,
+			],
 		]);
 	}
 

--- a/tests/Rules/Doctrine/ORM/data/repository-findBy-etc.php
+++ b/tests/Rules/Doctrine/ORM/data/repository-findBy-etc.php
@@ -45,4 +45,25 @@ class RepositoryFindByCalls
 		$entityRepository->count(['nonexistent' => 'test', 'transient' => 'test']);
 	}
 
+
+	public function doFindByOrder(): void
+	{
+		$entityRepository = $this->entityManager->getRepository(MyEntity::class);
+		$entityRepository->findBy([], ['id' => 'ASC']);
+		$entityRepository->findBy([], ['title' => 'DESC']);
+		$entityRepository->findBy([], ['transient' => 'ASC']);
+		$entityRepository->findBy([], ['nonexistent' => 'DESC']);
+		$entityRepository->findBy([], ['nonexistent' => 'ASC', 'transient' => 'DESC']);
+	}
+
+	public function doFindOneByOrder(): void
+	{
+		$entityRepository = $this->entityManager->getRepository(MyEntity::class);
+		$entityRepository->findOneBy([], ['id' => 'ASC']);
+		$entityRepository->findOneBy([], ['title' => 'DESC']);
+		$entityRepository->findOneBy([], ['transient' => 'ASC']);
+		$entityRepository->findOneBy([], ['nonexistent' => 'DESC']);
+		$entityRepository->findOneBy([], ['nonexistent' => 'ASC', 'transient' => 'DESC']);
+	}
+
 }


### PR DESCRIPTION
Check valid field names are used in orderBy parameter of findBy and findOneBy repository methods (issue #674).

Unfortunately this won't catch a nested call like this:

```
    public function findAll(array $orderBy = ['name' => 'ASC']): array
    {
        return $this->findBy([], $orderBy);
    }
```