### PR TITLE
Fix PHPStan crashing with single value enum

### DIFF
--- a/src/Rules/Doctrine/ORM/EntityColumnRule.php
+++ b/src/Rules/Doctrine/ORM/EntityColumnRule.php
@@ -22,7 +22,6 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypehintHelper;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeUtils;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use Throwable;
 use function count;
@@ -173,8 +172,8 @@ class EntityColumnRule implements Rule
 				}
 
 				if (count($enumTypes) > 0) {
-					$writableToPropertyType = new UnionType($enumTypes);
-					$writableToDatabaseType = new UnionType($enumTypes);
+					$writableToPropertyType = TypeCombinator::union(...$enumTypes);
+					$writableToDatabaseType = TypeCombinator::union(...$enumTypes);
 				}
 			}
 		}

--- a/src/Rules/Doctrine/ORM/EntityColumnRule.php
+++ b/src/Rules/Doctrine/ORM/EntityColumnRule.php
@@ -172,8 +172,9 @@ class EntityColumnRule implements Rule
 				}
 
 				if (count($enumTypes) > 0) {
-					$writableToPropertyType = TypeCombinator::union(...$enumTypes);
-					$writableToDatabaseType = TypeCombinator::union(...$enumTypes);
+					$unionType = TypeCombinator::union(...$enumTypes);
+					$writableToPropertyType = $unionType;
+					$writableToDatabaseType = $unionType;
 				}
 			}
 		}

--- a/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
@@ -478,4 +478,21 @@ class EntityColumnRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-679.php'], []);
 	}
 
+	/**
+	 * @dataProvider dataObjectManagerLoader
+	 */
+	public function testBugSingleEnum(?string $objectManagerLoader): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			self::markTestSkipped('Test requires PHP 8.1');
+		}
+		if (!class_exists(\Doctrine\DBAL\Types\EnumType::class)) {
+			self::markTestSkipped('Test requires EnumType.');
+		}
+
+		$this->allowNullablePropertyForRequiredField = false;
+		$this->objectManagerLoader = $objectManagerLoader;
+		$this->analyse([__DIR__ . '/data/bug-single-enum.php'], []);
+	}
+
 }

--- a/tests/Rules/Doctrine/ORM/data/bug-single-enum.php
+++ b/tests/Rules/Doctrine/ORM/data/bug-single-enum.php
@@ -1,0 +1,29 @@
+<?php // lint >= 8.1
+
+namespace PHPStan\Rules\Doctrine\ORM\BugSingleEnum;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class MyBrokenEntity
+{
+	public const LOGIN_METHOD_BASIC_AUTH = 'BasicAuth';
+
+	public const LOGIN_METHODS = [
+		self::LOGIN_METHOD_BASIC_AUTH,
+	];
+
+	/**
+	 * @var int|null
+	 */
+	#[ORM\Id]
+	#[ORM\GeneratedValue]
+	#[ORM\Column(type: 'integer')]
+	private $id;
+
+	/**
+	 * @var self::LOGIN_METHOD_*
+	 */
+	#[ORM\Column(name: 'login_method', type: 'enum', options: ['default' => self::LOGIN_METHOD_BASIC_AUTH, 'values' => self::LOGIN_METHODS])]
+	private string $loginMethod = self::LOGIN_METHOD_BASIC_AUTH;
+}


### PR DESCRIPTION
@ondrejmirtes I discovered a bug introduced by https://github.com/phpstan/phpstan-doctrine/pull/678

When an enum has only one value, I tried to do a Union of a single type and it crash with a ShouldNotHappenException.

I added a reproducer and a fix.