### PR TITLE
Mark more method with phpstan-impure

### DIFF
--- a/stubs/DocumentManager.stub
+++ b/stubs/DocumentManager.stub
@@ -15,6 +15,7 @@ class DocumentManager implements ObjectManager
 	 * @phpstan-param integer|null $lockMode
 	 * @phpstan-param integer|null $lockVersion
 	 * @phpstan-return T|null
+	 * @phpstan-impure
 	 */
 	public function find($documentName, $identifier, $lockMode = null, $lockVersion = null);
 

--- a/stubs/DocumentRepository.stub
+++ b/stubs/DocumentRepository.stub
@@ -16,11 +16,13 @@ class DocumentRepository implements ObjectRepository
 	 * @phpstan-param int|null $lockMode
 	 * @phpstan-param int|null $lockVersion
 	 * @phpstan-return TDocumentClass|null
+	 * @phpstan-impure
 	 */
 	public function find($id, $lockMode = null, $lockVersion = null);
 
 	/**
 	 * @phpstan-return array<int, TDocumentClass>
+	 * @phpstan-impure
 	 */
 	public function findAll();
 
@@ -30,12 +32,14 @@ class DocumentRepository implements ObjectRepository
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $skip
 	 * @phpstan-return array<int, TDocumentClass>
+	 * @phpstan-impure
 	 */
 	public function findBy(array $criteria, ?array $sort = null, $limit = null, $skip = null);
 
 	/**
 	 * @phpstan-param array<string, mixed> $criteria The criteria.
 	 * @phpstan-return TDocumentClass|null
+	 * @phpstan-impure
 	 */
 	public function findOneBy(array $criteria);
 

--- a/stubs/EntityManager.stub
+++ b/stubs/EntityManager.stub
@@ -14,6 +14,7 @@ class EntityManager implements EntityManagerInterface
 	 * @phpstan-param integer|null $lockMode
 	 * @phpstan-param integer|null $lockVersion
 	 * @phpstan-return T|null
+	 * @phpstan-impure
 	 */
 	public function find($entityName, $id, $lockMode = null, $lockVersion = null);
 

--- a/stubs/EntityManagerDecorator.stub
+++ b/stubs/EntityManagerDecorator.stub
@@ -16,6 +16,7 @@ class EntityManagerDecorator implements EntityManagerInterface
 	 * @phpstan-param integer|null $lockMode
 	 * @phpstan-param integer|null $lockVersion
 	 * @phpstan-return T|null
+	 * @phpstan-impure
 	 */
 	public function find($entityName, $id, $lockMode = null, $lockVersion = null);
 

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -15,6 +15,7 @@ interface EntityManagerInterface extends ObjectManager
 	 * @phpstan-param class-string<T> $className
 	 * @phpstan-param mixed  $id
 	 * @phpstan-return T|null
+	 * @phpstan-impure
 	 */
 	public function find($className, $id);
 

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -26,6 +26,7 @@ class EntityRepository implements ObjectRepository
 
 	/**
 	 * @phpstan-return list<TEntityClass>
+	 * @phpstan-impure
 	 */
 	public function findAll();
 
@@ -35,6 +36,7 @@ class EntityRepository implements ObjectRepository
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $offset
 	 * @phpstan-return list<TEntityClass>
+	 * @phpstan-impure
 	 */
 	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
 
@@ -77,6 +79,8 @@ class EntityRepository implements ObjectRepository
 	 * @param array<string, mixed> $criteria
 	 *
 	 * @return int<0, max>
+	 *
+	 * @phpstan-impure
 	 */
 	public function count(array $criteria);
 


### PR DESCRIPTION
Similar to https://github.com/phpstan/phpstan-doctrine/pull/648 but with more methods
- find method exists in EntityManager/DocumentManager
- find/findOne exists in DocumentRepository
- findAll/findBy/count are also technically impure the same way find is