### PR TITLE
Move phpstan analyse paths into phpstan.neon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ cs-fix:
 
 .PHONY: phpstan
 phpstan:
-	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon
+	php vendor/bin/phpstan analyse -c phpstan.neon
 
 .PHONY: phpstan-generate-baseline
 phpstan-generate-baseline:
-	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon -b phpstan-baseline.neon
+	php vendor/bin/phpstan analyse -c phpstan.neon -b phpstan-baseline.neon

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ cs-fix:
 
 .PHONY: phpstan
 phpstan:
-	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon src tests
+	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon
 
 .PHONY: phpstan-generate-baseline
 phpstan-generate-baseline:
-	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon src tests -b phpstan-baseline.neon
+	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon -b phpstan-baseline.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 
 parameters:
+	level: 8
 	paths:
 		- src
 		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,10 @@ includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 
 parameters:
+	paths:
+		- src
+		- tests
+
 	excludePaths:
 		- tests/*/data/*
 		- tests/*/data-attributes/*


### PR DESCRIPTION
deduplicate config, so we don't need another copy of it in the [infection setup PR](https://github.com/phpstan/phpstan-doctrine/pull/686).

in addition it eases configuring infection with phpstan, as it has such a misleading option handling.
at best we just have it in the config, so we don't need to fiddle with the additional options