### PR TITLE
Declare Connection::fetch methods as impure

### DIFF
--- a/stubs/DBAL/Connection.stub
+++ b/stubs/DBAL/Connection.stub
@@ -119,4 +119,101 @@ class Connection
      * @throws Exception
      */
     public function insert($table, array $data, array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return array<string, mixed>|false
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAssociative(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return list<mixed>|false
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchNumeric(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return mixed
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchOne(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return list<list<mixed>>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllNumeric(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return list<array<string,mixed>>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllAssociative(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return array<mixed,mixed>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllKeyValue(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return array<mixed,array<string,mixed>>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllAssociativeIndexed(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types
+     *
+     * @return list<mixed>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchFirstColumn(string $query, array $params = [], array $types = []);
+
 }

--- a/stubs/DBAL/Connection4.stub
+++ b/stubs/DBAL/Connection4.stub
@@ -123,4 +123,101 @@ class Connection
      * @throws Exception
      */
     public function insert(string $table, array $data, array $types = []): int|string;
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return array<string, mixed>|false
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAssociative(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return list<mixed>|false
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchNumeric(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return mixed
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchOne(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return list<list<mixed>>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllNumeric(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return list<array<string,mixed>>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllAssociative(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return array<mixed,mixed>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllKeyValue(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return array<mixed,array<string,mixed>>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchAllAssociativeIndexed(string $query, array $params = [], array $types = []);
+
+    /**
+     * @param list<mixed>|array<string, mixed> $params
+     * @param WrapperParameterTypeArray $types
+     *
+     * @return list<mixed>
+     *
+     * @throws Exception
+     *
+     * @phpstan-impure
+     */
+    public function fetchFirstColumn(string $query, array $params = [], array $types = []);
+
 }


### PR DESCRIPTION
Similar to https://github.com/phpstan/phpstan-doctrine/pull/685

This would avoid issue like this one https://github.com/phpstan/phpstan-phpunit/issues/232#issuecomment-3451309629
(cc @greg0ire)

Another solution could be to merge https://github.com/phpstan/phpstan-src/pull/4422 and use the new tag on the whole class.