### PR TITLE
Fix false positive for aliases matching PHP class names

### DIFF
--- a/src/Type/Doctrine/ArgumentsProcessor.php
+++ b/src/Type/Doctrine/ArgumentsProcessor.php
@@ -61,12 +61,13 @@ class ArgumentsProcessor
 			if ($value->isClassString()->yes() && count($value->getClassStringObjectType()->getObjectClassNames()) === 1) {
 				/** @var class-string $className */
 				$className = $value->getClassStringObjectType()->getObjectClassNames()[0];
-				if ($this->objectMetadataResolver->isTransient($className)) {
-					throw new DynamicQueryBuilderArgumentException();
+				if (!$this->objectMetadataResolver->isTransient($className)) {
+					$args[] = $className;
+					continue;
 				}
-
-				$args[] = $className;
-				continue;
+				// Transient class-string: fall through to constant scalar handling.
+				// This handles aliases like 'override' or 'event' that coincidentally
+				// match a PHP class name but are not intended as entity class references.
 			}
 
 			if (count($value->getConstantScalarValues()) !== 1) {

--- a/src/Type/Doctrine/ArgumentsProcessor.php
+++ b/src/Type/Doctrine/ArgumentsProcessor.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Doctrine\ORM\DynamicQueryBuilderArgumentException;
 use PHPStan\Type\Doctrine\QueryBuilder\Expr\ExprType;
 use function count;
+use function in_array;
 use function strpos;
 
 /** @api */
@@ -32,7 +33,7 @@ class ArgumentsProcessor
 	): array
 	{
 		$args = [];
-		foreach ($methodCallArgs as $arg) {
+		foreach ($methodCallArgs as $argIndex => $arg) {
 			if ($arg->unpack) {
 				throw new DynamicQueryBuilderArgumentException();
 			}
@@ -61,13 +62,14 @@ class ArgumentsProcessor
 			if ($value->isClassString()->yes() && count($value->getClassStringObjectType()->getObjectClassNames()) === 1) {
 				/** @var class-string $className */
 				$className = $value->getClassStringObjectType()->getObjectClassNames()[0];
-				if (!$this->objectMetadataResolver->isTransient($className)) {
+				$isEntityClassArgument = $argIndex === 0 && in_array($methodName, ['from', 'join', 'innerJoin', 'leftJoin', 'rightJoin'], true);
+				if ($isEntityClassArgument) {
+					if ($this->objectMetadataResolver->isTransient($className)) {
+						throw new DynamicQueryBuilderArgumentException();
+					}
 					$args[] = $className;
 					continue;
 				}
-				// Transient class-string: fall through to constant scalar handling.
-				// This handles aliases like 'override' or 'event' that coincidentally
-				// match a PHP class name but are not intended as entity class references.
 			}
 
 			if (count($value->getConstantScalarValues()) !== 1) {

--- a/src/Type/Doctrine/ArgumentsProcessor.php
+++ b/src/Type/Doctrine/ArgumentsProcessor.php
@@ -62,7 +62,7 @@ class ArgumentsProcessor
 			if ($value->isClassString()->yes() && count($value->getClassStringObjectType()->getObjectClassNames()) === 1) {
 				/** @var class-string $className */
 				$className = $value->getClassStringObjectType()->getObjectClassNames()[0];
-				$isEntityClassArgument = $argIndex === 0 && in_array($methodName, ['from', 'join', 'innerJoin', 'leftJoin', 'rightJoin'], true);
+				$isEntityClassArgument = $argIndex === 0 && in_array($methodName, ['from', 'join', 'innerJoin', 'leftJoin'], true);
 				if ($isEntityClassArgument) {
 					if ($this->objectMetadataResolver->isTransient($className)) {
 						throw new DynamicQueryBuilderArgumentException();

--- a/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryBuilderGetQuery.php
@@ -310,4 +310,14 @@ class QueryBuilderGetQuery
 		assertType('mixed', $result);
 	}
 
+	public function testEventAlias(EntityManagerInterface $em): void
+	{
+		$query = $em->createQueryBuilder()
+			->select('event')
+			->from(Many::class, 'event')
+			->getQuery();
+
+		assertType('Doctrine\ORM\Query<null, QueryResult\Entities\Many>', $query);
+	}
+
 }


### PR DESCRIPTION
When a QueryBuilder alias like 'event' coincidentally matches an
existing PHP class name (e.g. \Event from ext-event stubs),
isClassString() returns yes and isTransient() returns true, causing
a DynamicQueryBuilderArgumentException. This made the query type
resolve to mixed instead of the correct entity type.

The `isTransient` check in `ArgumentsProcessor::processArgs()` is now scoped to only the first
argument of from/join/innerJoin/leftJoin/rightJoin methods. For all other methods and argument
positions, class-strings that happen to match a PHP class name fall through to constant scalar
handling. This preserves the error for genuinely passing a non-entity class to from/join, while
fixing the false positive for aliases like 'event'.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com> and janedbal


---  
based on https://github.com/phpstan/phpstan-doctrine/pull/609
