### PR TITLE
Add literal string types for insert, update and delete methods

### DIFF
--- a/stubs/DBAL/Connection.stub
+++ b/stubs/DBAL/Connection.stub
@@ -74,4 +74,49 @@ class Connection
      */
     public function transactional(Closure $func);
 
+    /**
+     * Executes an SQL DELETE statement on a table.
+     *
+     * Table expression and columns are not escaped and are not safe for user-input.
+     *
+     * @param __doctrine-literal-string                                                               $table    Table name
+     * @param array<__doctrine-literal-string, mixed>                                                 $criteria Deletion criteria
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
+     *
+     * @return int|string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function delete($table, array $criteria, array $types = []);
+
+    /**
+     * Executes an SQL UPDATE statement on a table.
+     *
+     * Table expression and columns are not escaped and are not safe for user-input.
+     *
+     * @param __doctrine-literal-string                                                               $table    Table name
+     * @param array<__doctrine-literal-string, mixed>                                                 $data     Column-value pairs
+     * @param array<__doctrine-literal-string, mixed>                                                 $criteria Update criteria
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types    Parameter types
+     *
+     * @return int|string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function update($table, array $data, array $criteria, array $types = []);
+
+    /**
+     * Inserts a table row with specified data.
+     *
+     * Table expression and columns are not escaped and are not safe for user-input.
+     *
+     * @param __doctrine-literal-string                                                               $table Table name
+     * @param array<__doctrine-literal-string, mixed>                                                 $data  Column-value pairs
+     * @param array<int, int|string|Type|null>|array<string, int|string|Type|null> $types Parameter types
+     *
+     * @return int|string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function insert($table, array $data, array $types = []);
 }

--- a/stubs/DBAL/Connection4.stub
+++ b/stubs/DBAL/Connection4.stub
@@ -78,4 +78,49 @@ class Connection
      */
     public function transactional(Closure $func);
 
+    /**
+     * Executes an SQL DELETE statement on a table.
+     *
+     * Table expression and columns are not escaped and are not safe for user-input.
+     *
+     * @param __doctrine-literal-string                                                             $table
+     * @param array<__doctrine-literal-string, mixed>                                               $criteria
+     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     *
+     * @return int|numeric-string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function delete(string $table, array $criteria = [], array $types = []): int|string;
+
+    /**
+     * Executes an SQL UPDATE statement on a table.
+     *
+     * Table expression and columns are not escaped and are not safe for user-input.
+     *
+     * @param __doctrine-literal-string                                                             $table
+     * @param array<__doctrine-literal-string, mixed>                                               $data
+     * @param array<__doctrine-literal-string, mixed>                                               $criteria
+     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     *
+     * @return int|numeric-string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function update(string $table, array $data, array $criteria = [], array $types = []): int|string;
+
+    /**
+     * Inserts a table row with specified data.
+     *
+     * Table expression and columns are not escaped and are not safe for user-input.
+     *
+     * @param __doctrine-literal-string                                                             $table
+     * @param array<__doctrine-literal-string, mixed>                                               $data
+     * @param array<int<0,max>, string|ParameterType|Type>|array<string, string|ParameterType|Type> $types
+     *
+     * @return int|numeric-string The number of affected rows.
+     *
+     * @throws Exception
+     */
+    public function insert(string $table, array $data, array $types = []): int|string;
 }


### PR DESCRIPTION
Add literal string types for the insert, update and delete methods of the connection class.

I'm not quite sure how to test these changes, as i couldn't find any tests files that check the other literal string types.

Fixes #719 