### PR TITLE
First-class callable crash on Expr methods

### DIFF
--- a/src/Type/Doctrine/QueryBuilder/Expr/BaseExpressionDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/Expr/BaseExpressionDynamicReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\Doctrine\ORM\DynamicQueryBuilderArgumentException;
 use PHPStan\Type\Doctrine\ArgumentsProcessor;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
+use Throwable;
 use function get_class;
 use function in_array;
 use function is_object;
@@ -55,7 +56,12 @@ class BaseExpressionDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 			return null;
 		}
 
-		$exprValue = $expr->{$methodReflection->getName()}(...$args);
+		try {
+			$exprValue = $expr->{$methodReflection->getName()}(...$args);
+		} catch (Throwable $e) {
+			return null;
+		}
+
 		if (is_object($exprValue)) {
 			return new ExprType(get_class($exprValue), $exprValue);
 		}

--- a/src/Type/Doctrine/QueryBuilder/Expr/ExpressionBuilderDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/Expr/ExpressionBuilderDynamicReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\Doctrine\ArgumentsProcessor;
 use PHPStan\Type\Doctrine\ObjectMetadataResolver;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
+use Throwable;
 use function get_class;
 use function is_object;
 use function method_exists;
@@ -74,7 +75,12 @@ class ExpressionBuilderDynamicReturnTypeExtension implements DynamicMethodReturn
 			return null;
 		}
 
-		$exprValue = $expr->{$methodReflection->getName()}(...$args);
+		try {
+			$exprValue = $expr->{$methodReflection->getName()}(...$args);
+		} catch (Throwable $e) {
+			return null;
+		}
+
 		if (is_object($exprValue)) {
 			return new ExprType(get_class($exprValue), $exprValue);
 		}

--- a/tests/Rules/Doctrine/ORM/QueryBuilderDqlFirstClassCallableTest.php
+++ b/tests/Rules/Doctrine/ORM/QueryBuilderDqlFirstClassCallableTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Doctrine\ObjectMetadataResolver;
+
+/**
+ * @extends RuleTestCase<QueryBuilderDqlRule>
+ */
+class QueryBuilderDqlFirstClassCallableTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new QueryBuilderDqlRule(
+			new ObjectMetadataResolver(__DIR__ . '/entity-manager.php', __DIR__ . '/../../../../tmp'),
+			true,
+		);
+	}
+
+	public function testFirstClassCallableInMatchArm(): void
+	{
+		$this->analyse([__DIR__ . '/data/query-builder-first-class-callable.php'], []);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../../extension.neon',
+			__DIR__ . '/entity-manager.neon',
+		];
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/data/query-builder-first-class-callable.php
+++ b/tests/Rules/Doctrine/ORM/data/query-builder-first-class-callable.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace PHPStan\Rules\Doctrine\ORM;
+
+use Doctrine\ORM\EntityManager;
+
+class TestFirstClassCallableExpr
+{
+
+	/** @var EntityManager */
+	private $entityManager;
+
+	public function __construct(EntityManager $entityManager)
+	{
+		$this->entityManager = $entityManager;
+	}
+
+	public function matchArmWithFirstClassCallable(): void
+	{
+		$queryBuilder = $this->entityManager->createQueryBuilder();
+		$expr = $queryBuilder->expr();
+
+		$comparator = match (random_int(0, 1)) {
+			0 => $expr->in(...),
+			1 => $expr->notIn(...),
+		};
+
+		$queryBuilder->select('e')
+			->from(MyEntity::class, 'e')
+			->andWhere($comparator('e.id', [1, 2, 3]));
+		$queryBuilder->getQuery();
+	}
+
+	public function variableWithFirstClassCallable(): void
+	{
+		$queryBuilder = $this->entityManager->createQueryBuilder();
+		$expr = $queryBuilder->expr();
+
+		$fn = $expr->eq(...);
+
+		$queryBuilder->select('e')
+			->from(MyEntity::class, 'e')
+			->andWhere($fn('e.id', '1'));
+		$queryBuilder->getQuery();
+	}
+
+}

--- a/tests/Type/Doctrine/data/QueryResult/baseExpressionAndOr.php
+++ b/tests/Type/Doctrine/data/QueryResult/baseExpressionAndOr.php
@@ -14,3 +14,6 @@ assertType("Doctrine\ORM\Query\Expr\Andx", $modifiedAnd);
 
 $string = $and->__toString();
 assertType("string", $string);
+
+$invalidAdd = $and->add(123);
+assertType("Doctrine\ORM\Query\Expr\Andx", $invalidAdd);


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan-doctrine/issues/711

Repro https://github.com/phpstan/phpstan-doctrine/actions/runs/22821964729/job/66196045235?pr=735#step:9:28

When first-class callable syntax ($expr->in(...)) is used inside match arms or assigned to variables, PHPStan resolves the closure and visits the extension with a MethodCall where isFirstClassCallable() is false and getArgs() is empty. This causes the actual Expr method to be called with 0 arguments, crashing with ArgumentCountError.

Fix with try/catch Throwable around the reflective method invocation for indirect cases (match arms, variable assignments). We also need to cover TypeError from ORM 3.x's typed signatures, plus any other unexpected exception from the reflective call.