### PR TITLE
Allow running the test-suite when mongo extension is not loaded

### DIFF
--- a/tests/DoctrineIntegration/ODM/DocumentManagerTypeInferenceTest.php
+++ b/tests/DoctrineIntegration/ODM/DocumentManagerTypeInferenceTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\DoctrineIntegration\ODM;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use function extension_loaded;
 use const PHP_VERSION_ID;
 
 final class DocumentManagerTypeInferenceTest extends TypeInferenceTestCase
@@ -10,6 +11,10 @@ final class DocumentManagerTypeInferenceTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
+		if (!extension_loaded('mongo')) {
+			self::markTestSkipped('MongoDB extension is not installed.');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/documentManagerDynamicReturn.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/documentRepositoryDynamicReturn.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/documentManagerMergeReturn.php');

--- a/tests/DoctrineIntegration/ODM/DocumentManagerTypeInferenceTest.php
+++ b/tests/DoctrineIntegration/ODM/DocumentManagerTypeInferenceTest.php
@@ -11,7 +11,7 @@ final class DocumentManagerTypeInferenceTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
-		if (!extension_loaded('mongo')) {
+		if (!extension_loaded('mongodb')) {
 			self::markTestSkipped('MongoDB extension is not installed.');
 		}
 


### PR DESCRIPTION
before this change you would run into the following exception, when running `make tests` and ext-mongo is not loaded:

```
➜  phpstan-doctrine git:(2.0.x) make tests
php vendor/bin/phpunit
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Random Seed:   1773070154
Warning:       No code coverage driver available

........................SS....SS..................SS...........  63 / 448 ( 14%)
............................................................... 126 / 448 ( 28%)
............................................................... 189 / 448 ( 42%)
..E........................SSSSSS.............................. 252 / 448 ( 56%)
............................................................... 315 / 448 ( 70%)
............................................................... 378 / 448 ( 84%)
............................................................... 441 / 448 ( 98%)
.......                                                         448 / 448 (100%)

Time: 00:47.214, Memory: 438.50 MB

There was 1 error:

1) Error
The data provider specified for PHPStan\DoctrineIntegration\ODM\DocumentManagerTypeInferenceTest::testFileAsserts is invalid.
Error: Class "MongoDB\Driver\Manager" not found
/Users/m.staab/dvl/phpstan-doctrine/vendor/mongodb/mongodb/src/Client.php:103
/Users/m.staab/dvl/phpstan-doctrine/vendor/doctrine/mongodb-odm/src/DocumentManager.php:151
/Users/m.staab/dvl/phpstan-doctrine/vendor/doctrine/mongodb-odm/src/DocumentManager.php:222
/Users/m.staab/dvl/phpstan-doctrine/tests/DoctrineIntegration/ODM/document-manager.php:23
/Users/m.staab/dvl/phpstan-doctrine/src/Type/Doctrine/ObjectMetadataResolver.php:191
/Users/m.staab/dvl/phpstan-doctrine/src/Type/Doctrine/ObjectMetadataResolver.php:64
/Users/m.staab/dvl/phpstan-doctrine/src/Type/Doctrine/ObjectMetadataResolver.php:102
/Users/m.staab/dvl/phpstan-doctrine/src/Type/Doctrine/ObjectMetadataResolver.php:142
/Users/m.staab/dvl/phpstan-doctrine/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php:152
/Users/m.staab/dvl/phpstan-doctrine/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php:109
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:3486
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:4250
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1098
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:684
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:854
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:684
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:2053
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:822
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:519
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:497
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:718
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:519
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:497
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:896
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:519
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:497
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:849
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/NodeScopeResolver.php:441
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TypeInferenceTestCase.php:88
phar:///Users/m.staab/dvl/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TypeInferenceTestCase.php:163
/Users/m.staab/dvl/phpstan-doctrine/tests/DoctrineIntegration/ODM/DocumentManagerTypeInferenceTest.php:14

ERRORS!
Tests: 448, Assertions: 8306, Errors: 1, Skipped: 12.
make: *** [tests] Error 2
```