### PR TITLE
Mark EntityManagerInterface::isOpen() as impure

### DIFF
--- a/stubs/EntityManager.stub
+++ b/stubs/EntityManager.stub
@@ -70,4 +70,9 @@ class EntityManager implements EntityManagerInterface
      */
     public function flush($entity = null);
 
+	/**
+	 * @return bool
+	 * @phpstan-impure
+	 */
+	public function isOpen();
 }

--- a/stubs/EntityManagerDecorator.stub
+++ b/stubs/EntityManagerDecorator.stub
@@ -61,4 +61,9 @@ class EntityManagerDecorator implements EntityManagerInterface
 	 */
 	public function copy($entity, $deep = false);
 
+	/**
+	 * @return bool
+	 * @phpstan-impure
+	 */
+	public function isOpen();
 }

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -78,4 +78,9 @@ interface EntityManagerInterface extends ObjectManager
 	 */
 	public function wrapInTransaction(callable $func);
 
+	/**
+	 * @return bool
+	 * @phpstan-impure
+	 */
+	public function isOpen();
 }


### PR DESCRIPTION
The result of isOpen() depends on the internal state of the EntityManager
and may change during execution (for example after an exception during flush()).

This change follows the existing approach used for other Doctrine methods
that depend on mutable internal state.

Fixes #738 