### PR TITLE
Fix return type on `EntityRepository::matching()` generics

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -115,6 +115,10 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
+		class: PHPStan\Type\Doctrine\EntityRepositoryMatchingDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
 		class: PHPStan\Type\Doctrine\ObjectMetadataResolver
 		arguments:
 			objectManagerLoader: %doctrine.objectManagerLoader%

--- a/src/Type/Doctrine/EntityRepositoryMatchingDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityRepositoryMatchingDynamicReturnTypeExtension.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use Doctrine\ORM\EntityRepository;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+
+class EntityRepositoryMatchingDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return EntityRepository::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'matching';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		$callerType = $scope->getType($methodCall->var);
+		$entityType = $callerType->getTemplateType(EntityRepository::class, 'TEntityClass');
+
+		return new IntersectionType([
+			new GenericObjectType('Doctrine\Common\Collections\Collection', [new IntegerType(), $entityType]),
+			new GenericObjectType('Doctrine\Common\Collections\Selectable', [new IntegerType(), $entityType]),
+		]);
+	}
+
+}

--- a/src/Type/Doctrine/EntityRepositoryMatchingDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/EntityRepositoryMatchingDynamicReturnTypeExtension.php
@@ -8,8 +8,8 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Type;
 
 class EntityRepositoryMatchingDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -2,10 +2,10 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Persistence\EntityRepository;
-use Doctrine\Persistence\ObjectManager;
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 
 interface EntityManagerInterface extends ObjectManager
 {

--- a/stubs/EntityManagerInterface.stub
+++ b/stubs/EntityManagerInterface.stub
@@ -2,8 +2,8 @@
 
 namespace Doctrine\ORM;
 
+use Doctrine\Persistence\EntityRepository;
 use Doctrine\Persistence\ObjectManager;
-use Doctrine\Persistence\ObjectRepository;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
@@ -29,7 +29,7 @@ interface EntityManagerInterface extends ObjectManager
 	/**
 	 * @template T of object
 	 * @phpstan-param class-string<T> $className
-	 * @phpstan-return ObjectRepository<T>
+	 * @phpstan-return EntityRepository<T>
 	 */
 	public function getRepository($className);
 

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -61,9 +61,7 @@ class EntityRepository implements ObjectRepository
 	/**
 	 * @param \Doctrine\Common\Collections\Criteria $criteria
 	 *
-	 * @return \Doctrine\Common\Collections\Collection
-	 *
-	 * @psalm-return \Doctrine\Common\Collections\Collection<int, TEntityClass>
+	 * @phpstan-return \Doctrine\Common\Collections\AbstractLazyCollection<int, TEntityClass>
 	 */
 	public function matching(Criteria $criteria);
 

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -2,9 +2,7 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Collections\Selectable;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
@@ -59,13 +57,6 @@ class EntityRepository implements ObjectRepository
 	 * @phpstan-return class-string<TEntityClass>
 	 */
 	protected function getEntityName();
-
-	/**
-	 * @param Criteria $criteria
-	 *
-	 * @phpstan-return Collection<int, TEntityClass>&Selectable<int, TEntityClass>
-	 */
-	public function matching(Criteria $criteria);
 
 	/**
 	 * @param __doctrine-literal-string      $alias

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -61,7 +61,7 @@ class EntityRepository implements ObjectRepository
 	/**
 	 * @param \Doctrine\Common\Collections\Criteria $criteria
 	 *
-	 * @phpstan-return \Doctrine\Common\Collections\AbstractLazyCollection<int, TEntityClass>
+	 * @phpstan-return \Doctrine\Common\Collections\AbstractLazyCollection<int, TEntityClass>&\Doctrine\Common\Collections\Selectable<int, TEntityClass>
 	 */
 	public function matching(Criteria $criteria);
 

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -2,7 +2,7 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Collections\AbstractLazyCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Persistence\ObjectRepository;
@@ -63,7 +63,7 @@ class EntityRepository implements ObjectRepository
 	/**
 	 * @param Criteria $criteria
 	 *
-	 * @phpstan-return AbstractLazyCollection<int, TEntityClass>&Selectable<int, TEntityClass>
+	 * @phpstan-return Collection<int, TEntityClass>&Selectable<int, TEntityClass>
 	 */
 	public function matching(Criteria $criteria);
 

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -2,7 +2,9 @@
 
 namespace Doctrine\ORM;
 
+use Doctrine\Common\Collections\AbstractLazyCollection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
@@ -59,9 +61,9 @@ class EntityRepository implements ObjectRepository
 	protected function getEntityName();
 
 	/**
-	 * @param \Doctrine\Common\Collections\Criteria $criteria
+	 * @param Criteria $criteria
 	 *
-	 * @phpstan-return \Doctrine\Common\Collections\AbstractLazyCollection<int, TEntityClass>&\Doctrine\Common\Collections\Selectable<int, TEntityClass>
+	 * @phpstan-return AbstractLazyCollection<int, TEntityClass>&Selectable<int, TEntityClass>
 	 */
 	public function matching(Criteria $criteria);
 

--- a/tests/DoctrineIntegration/TypeInferenceTest.php
+++ b/tests/DoctrineIntegration/TypeInferenceTest.php
@@ -12,6 +12,7 @@ class TypeInferenceTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/getRepository.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/isEmpty.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/Collection.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/repositoryMatching.php');
 	}
 
 	/**

--- a/tests/DoctrineIntegration/data/repositoryMatching.php
+++ b/tests/DoctrineIntegration/data/repositoryMatching.php
@@ -17,8 +17,11 @@ class Foo
 	{
 		$repository = $this->entityManager->getRepository(MyEntity::class);
 		$criteria = Criteria::create();
-		$result = $repository->matching($criteria);
-		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $result);
+		$results = $repository->matching($criteria);
+		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $results);
+		foreach ($results as $result) {
+			assertType(MyEntity::class, $result);
+		}
 	}
 
 	/**
@@ -27,8 +30,11 @@ class Foo
 	public function withTypedRepository(EntityRepository $repository): void
 	{
 		$criteria = Criteria::create();
-		$result = $repository->matching($criteria);
-		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $result);
+		$results = $repository->matching($criteria);
+		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $results);
+		foreach ($results as $result) {
+			assertType(MyEntity::class, $result);
+		}
 	}
 
 }

--- a/tests/DoctrineIntegration/data/repositoryMatching.php
+++ b/tests/DoctrineIntegration/data/repositoryMatching.php
@@ -18,7 +18,7 @@ class Foo
 		$repository = $this->entityManager->getRepository(MyEntity::class);
 		$criteria = Criteria::create();
 		$results = $repository->matching($criteria);
-		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $results);
+		assertType('Doctrine\Common\Collections\Collection<int, RepositoryMatching\MyEntity>&Doctrine\Common\Collections\Selectable<int, RepositoryMatching\MyEntity>', $results);
 		foreach ($results as $result) {
 			assertType(MyEntity::class, $result);
 		}
@@ -31,7 +31,7 @@ class Foo
 	{
 		$criteria = Criteria::create();
 		$results = $repository->matching($criteria);
-		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $results);
+		assertType('Doctrine\Common\Collections\Collection<int, RepositoryMatching\MyEntity>&Doctrine\Common\Collections\Selectable<int, RepositoryMatching\MyEntity>', $results);
 		foreach ($results as $result) {
 			assertType(MyEntity::class, $result);
 		}

--- a/tests/DoctrineIntegration/data/repositoryMatching.php
+++ b/tests/DoctrineIntegration/data/repositoryMatching.php
@@ -18,7 +18,7 @@ class Foo
 		$repository = $this->entityManager->getRepository(MyEntity::class);
 		$criteria = Criteria::create();
 		$result = $repository->matching($criteria);
-		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>&Doctrine\Common\Collections\Selectable<int, RepositoryMatching\MyEntity>', $result);
+		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $result);
 	}
 
 	/**
@@ -28,7 +28,7 @@ class Foo
 	{
 		$criteria = Criteria::create();
 		$result = $repository->matching($criteria);
-		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>&Doctrine\Common\Collections\Selectable<int, RepositoryMatching\MyEntity>', $result);
+		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>', $result);
 	}
 
 }

--- a/tests/DoctrineIntegration/data/repositoryMatching.php
+++ b/tests/DoctrineIntegration/data/repositoryMatching.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace RepositoryMatching;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/** @var EntityManager */
+	private $entityManager;
+
+	public function doFoo(): void
+	{
+		$repository = $this->entityManager->getRepository(MyEntity::class);
+		$criteria = Criteria::create();
+		$result = $repository->matching($criteria);
+		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>&Doctrine\Common\Collections\Selectable<int, RepositoryMatching\MyEntity>', $result);
+	}
+
+	/**
+	 * @param EntityRepository<MyEntity> $repository
+	 */
+	public function withTypedRepository(EntityRepository $repository): void
+	{
+		$criteria = Criteria::create();
+		$result = $repository->matching($criteria);
+		assertType('Doctrine\Common\Collections\AbstractLazyCollection<int, RepositoryMatching\MyEntity>&Doctrine\Common\Collections\Selectable<int, RepositoryMatching\MyEntity>', $result);
+	}
+
+}
+
+class MyEntity
+{
+
+}


### PR DESCRIPTION
Fixes a regression where the collection returned by matching() would lose the generic metadata, and downstream code reading the values would get `mixed`.

e.g. this worked under ORM2 + this plugin, but fails under ORM3 because $feed became mixed:
```php
        $feeds = $this->em->getRepository(Feed::class)
            ->matching($crit);

        foreach ($feeds as $feed) {
            $this->submitter->submitUpdateFeedJob($feed);
        }
```

This changed in ORM3, which actually has native types that are correct and were being overridden by the stub. I've updated the stub and added a test to reflect the return value.

Note: ORM3 specifies `AbstractLazyCollection&Selectable` as the return type, but `AbstractLazyCollection` already implements `Selectable` so PHPStan refines it out as redundant.

