### PR TITLE
Rely on same template name than doctrine

### DIFF
--- a/src/Reflection/Doctrine/EntityRepositoryClassReflectionExtension.php
+++ b/src/Reflection/Doctrine/EntityRepositoryClassReflectionExtension.php
@@ -55,7 +55,7 @@ class EntityRepositoryClassReflectionExtension implements MethodsClassReflection
 		}
 
 		$templateTypeMap = $repositoryAncesor->getActiveTemplateTypeMap();
-		$entityClassType = $templateTypeMap->getType('TEntityClass');
+		$entityClassType = $templateTypeMap->getType('T');
 		if ($entityClassType === null) {
 			return false;
 		}
@@ -91,7 +91,7 @@ class EntityRepositoryClassReflectionExtension implements MethodsClassReflection
 		}
 
 		$templateTypeMap = $repositoryAncesor->getActiveTemplateTypeMap();
-		$entityClassType = $templateTypeMap->getType('TEntityClass');
+		$entityClassType = $templateTypeMap->getType('T');
 		if ($entityClassType === null) {
 			throw new ShouldNotHappenException();
 		}

--- a/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
+++ b/src/Rules/Doctrine/ORM/RepositoryMethodCallRule.php
@@ -38,7 +38,7 @@ class RepositoryMethodCallRule implements Rule
 		}
 		$argType = $scope->getType($node->getArgs()[0]->value);
 		$calledOnType = $scope->getType($node->var);
-		$entityClassType = $calledOnType->getTemplateType(ObjectRepository::class, 'TEntityClass');
+		$entityClassType = $calledOnType->getTemplateType(ObjectRepository::class, 'T');
 
 		/** @var list<class-string> $entityClassNames */
 		$entityClassNames = $entityClassType->getObjectClassNames();

--- a/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
@@ -127,7 +127,7 @@ class GetRepositoryDynamicReturnTypeExtension implements DynamicMethodReturnType
 			$args,
 			$methodReflection->getVariants(),
 		)->getReturnType();
-		$entity = $defaultType->getTemplateType(ObjectRepository::class, 'TEntityClass');
+		$entity = $defaultType->getTemplateType(ObjectRepository::class, 'T');
 		if (!$entity instanceof ErrorType) {
 			return new GenericObjectType(
 				$defaultRepositoryClass,

--- a/stubs/EntityRepository.stub
+++ b/stubs/EntityRepository.stub
@@ -8,26 +8,26 @@ use Doctrine\Common\Collections\Selectable;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
- * @template TEntityClass of object
- * @implements ObjectRepository<TEntityClass>
+ * @template T of object
+ * @implements ObjectRepository<T>
  */
 class EntityRepository implements ObjectRepository
 {
 
-	/** @var class-string<TEntityClass> */
+	/** @var class-string<T> */
 	protected $_entityName;
 
 	/**
 	 * @phpstan-param mixed $id
 	 * @phpstan-param int|null $lockMode
 	 * @phpstan-param int|null $lockVersion
-	 * @phpstan-return TEntityClass|null
+	 * @phpstan-return T|null
 	 * @phpstan-impure
 	 */
 	public function find($id, $lockMode = null, $lockVersion = null);
 
 	/**
-	 * @phpstan-return list<TEntityClass>
+	 * @phpstan-return list<T>
 	 * @phpstan-impure
 	 */
 	public function findAll();
@@ -37,7 +37,7 @@ class EntityRepository implements ObjectRepository
 	 * @phpstan-param array<string, string>|null $orderBy
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $offset
-	 * @phpstan-return list<TEntityClass>
+	 * @phpstan-return list<T>
 	 * @phpstan-impure
 	 */
 	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
@@ -45,25 +45,25 @@ class EntityRepository implements ObjectRepository
 	/**
 	 * @phpstan-param array<string, mixed> $criteria The criteria.
 	 * @phpstan-param array<string, string>|null $orderBy
-	 * @phpstan-return TEntityClass|null
+	 * @phpstan-return T|null
 	 * @phpstan-impure
 	 */
 	public function findOneBy(array $criteria, ?array $orderBy = null);
 
 	/**
-	 * @phpstan-return class-string<TEntityClass>
+	 * @phpstan-return class-string<T>
 	 */
 	public function getClassName();
 
 	/**
-	 * @phpstan-return class-string<TEntityClass>
+	 * @phpstan-return class-string<T>
 	 */
 	protected function getEntityName();
 
 	/**
 	 * @param Criteria $criteria
 	 *
-	 * @phpstan-return AbstractLazyCollection<int, TEntityClass>&Selectable<int, TEntityClass>
+	 * @phpstan-return AbstractLazyCollection<int, T>&Selectable<int, T>
 	 */
 	public function matching(Criteria $criteria);
 

--- a/stubs/LazyServiceEntityRepository.stub
+++ b/stubs/LazyServiceEntityRepository.stub
@@ -4,15 +4,15 @@ namespace Doctrine\Bundle\DoctrineBundle\Repository;
 use Doctrine\ORM\EntityRepository;
 
 /**
- * @template TEntityClass of object
- * @template-extends LazyServiceEntityRepository<TEntityClass>
+ * @template T of object
+ * @template-extends LazyServiceEntityRepository<T>
  */
 class ServiceEntityRepository extends LazyServiceEntityRepository {
 }
 
 /**
- * @template TEntityClass of object
- * @template-extends EntityRepository<TEntityClass>
+ * @template T of object
+ * @template-extends EntityRepository<T>
  */
 class LazyServiceEntityRepository extends EntityRepository {
 }

--- a/stubs/Persistence/ObjectRepository.stub
+++ b/stubs/Persistence/ObjectRepository.stub
@@ -3,19 +3,19 @@
 namespace Doctrine\Persistence;
 
 /**
- * @template-covariant TEntityClass of object
+ * @template-covariant T of object
  */
 interface ObjectRepository
 {
 
 	/**
 	 * @phpstan-param mixed $id
-	 * @phpstan-return TEntityClass|null
+	 * @phpstan-return T|null
 	 */
 	public function find($id);
 
 	/**
-	 * @phpstan-return array<int, TEntityClass>
+	 * @phpstan-return array<int, T>
 	 */
 	public function findAll();
 
@@ -24,18 +24,18 @@ interface ObjectRepository
 	 * @phpstan-param array<string, string>|null $orderBy
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $offset
-	 * @phpstan-return array<int, TEntityClass>
+	 * @phpstan-return array<int, T>
 	 */
 	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
 
 	/**
 	 * @phpstan-param array<string, mixed> $criteria The criteria.
-	 * @phpstan-return TEntityClass|null
+	 * @phpstan-return T|null
 	 */
 	public function findOneBy(array $criteria);
 
 	/**
-	 * @phpstan-return class-string<TEntityClass>
+	 * @phpstan-return class-string<T>
 	 */
 	public function getClassName();
 

--- a/stubs/RepositoryFactory.stub
+++ b/stubs/RepositoryFactory.stub
@@ -8,9 +8,9 @@ use Doctrine\ORM\EntityManagerInterface;
 interface RepositoryFactory
 {
     /**
-     * @template TEntityClass of object
-     * @phpstan-param class-string<TEntityClass> $entityName
-     * @phpstan-return ObjectRepository<TEntityClass>
+     * @template T of object
+     * @phpstan-param class-string<T> $entityName
+     * @phpstan-return ObjectRepository<T>
      */
     public function getRepository(EntityManagerInterface $entityManager, $entityName);
 }

--- a/stubs/ServiceEntityRepository.stub
+++ b/stubs/ServiceEntityRepository.stub
@@ -4,8 +4,8 @@ namespace Doctrine\Bundle\DoctrineBundle\Repository;
 use \Doctrine\ORM\EntityRepository;
 
 /**
- * @template TEntityClass of object
- * @template-extends EntityRepository<TEntityClass>
+ * @template T of object
+ * @template-extends EntityRepository<T>
  */
 class ServiceEntityRepository extends EntityRepository {
 }

--- a/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-6.json
+++ b/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-6.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Property PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\Example::$repository with generic class Doctrine\\ORM\\EntityRepository does not specify its types: TEntityClass",
+        "message": "Property PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\Example::$repository with generic class Doctrine\\ORM\\EntityRepository does not specify its types: T",
         "line": 16,
         "ignorable": true
     },
     {
-        "message": "Class PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\Bug180Repository extends generic class Doctrine\\ORM\\EntityRepository but does not specify its types: TEntityClass",
+        "message": "Class PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\Bug180Repository extends generic class Doctrine\\ORM\\EntityRepository but does not specify its types: T",
         "line": 232,
         "ignorable": true
     }


### PR DESCRIPTION
Cf https://github.com/doctrine/DoctrineBundle/blob/9898f367da071d3d81084aa6007ab4d80437e62f/src/Repository/ServiceEntityRepository.php#L35
https://github.com/doctrine/persistence/blob/d138f3ab5f761055cab1054070377cfd3222e368/lib/Doctrine/Persistence/ObjectRepository.php#L10
https://github.com/doctrine/orm/blob/495cd06b9a630f9c38a21ceb249ed008edbe8414/lib/Doctrine/ORM/EntityRepository.php#L36
and so...

This avoid error like
https://github.com/phpstan/phpstan-doctrine/pull/742#issuecomment-4373485328