### PR TITLE
Add collision-detector.json to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@ phpstan-baseline-*.neon export-ignore
 phpunit.xml export-ignore
 stubs/runtime/Enum/UnitEnum.php export-ignore
 stubs/runtime/Enum/BackedEnum.php export-ignore
+/collision-detector.json export-ignore


### PR DESCRIPTION
Current archive targets other than src/ will be as follows:
```bash
gh api repos/phpstan/phpstan-doctrine/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
collision-detector.json
composer.json
extension.neon
LICENSE
README.md
rules.neon
stubs/
stubs/Collections/
stubs/Collections/AbstractLazyCollection.stub
stubs/Collections/ArrayCollection.stub
stubs/Collections/Collection1.stub
stubs/Collections/Collection.stub
stubs/Collections/ReadableCollection1.stub
stubs/Collections/ReadableCollection.stub
stubs/Collections/Selectable.stub
stubs/Criteria.stub
stubs/DBAL/
stubs/DBAL/ArrayParameterType.stub
stubs/DBAL/Cache/
stubs/DBAL/Cache/CacheException.stub
stubs/DBAL/Cache/QueryCacheProfile.stub
stubs/DBAL/Connection4.stub
stubs/DBAL/Connection.stub
stubs/DBAL/Exception/
stubs/DBAL/Exception.stub
stubs/DBAL/Exception/UniqueConstraintViolationException.stub
stubs/DBAL/ParameterType.stub
stubs/DBAL/Result.stub
stubs/DBAL/Statement.stub
stubs/DBAL/Types/
stubs/DBAL/Types/Type.stub
stubs/DocumentManager.stub
stubs/DocumentRepository.stub
stubs/EntityManagerDecorator.stub
stubs/EntityManagerInterface.stub
stubs/EntityManager.stub
stubs/EntityRepository.stub
stubs/LazyServiceEntityRepository.stub
stubs/MongoClassMetadataInfo.stub
stubs/ORM/
stubs/ORM/AbstractQuery.stub
stubs/ORM/Exception/
stubs/ORM/Exception/ORMException.stub
stubs/ORM/Id/
stubs/ORM/Id/AbstractIdGenerator.stub
stubs/ORM/Mapping/
stubs/ORM/Mapping/ClassMetadataInfo.stub
stubs/ORM/Mapping/ClassMetadata.stub
stubs/ORM/Mapping/ManyToManyInverseSideMapping.stub
stubs/ORM/Mapping/ManyToManyOwningSideMapping.stub
stubs/ORM/Mapping/ManyToOneAssociationMapping.stub
stubs/ORM/Mapping/OneToManyAssociationMapping.stub
stubs/ORM/Mapping/OneToOneInverseSideMapping.stub
stubs/ORM/Mapping/OneToOneOwningSideMapping.stub
stubs/ORM/NonUniqueResultException.stub
stubs/ORM/NoResultException.stub
stubs/ORM/ORMException.stub
stubs/ORM/Query/
stubs/ORM/QueryBuilder.stub
stubs/ORM/Query/Expr/
stubs/ORM/Query/Expr/Comparison.stub
stubs/ORM/Query/Expr/Composite.stub
stubs/ORM/Query/Expr/Func.stub
stubs/ORM/Query/Expr/Join.stub
stubs/ORM/Query/Expr.stub
stubs/ORM/Query.stub
stubs/ORM/Tools/
stubs/ORM/Tools/Pagination/
stubs/ORM/Tools/Pagination/Paginator.stub
stubs/ORM/UnexpectedResultException.stub
stubs/Persistence/
stubs/Persistence/ManagerRegistry.stub
stubs/Persistence/Mapping/
stubs/Persistence/Mapping/ClassMetadata.stub
stubs/Persistence/ObjectManagerDecorator.stub
stubs/Persistence/ObjectManager.stub
stubs/Persistence/ObjectRepository.stub
stubs/RepositoryFactory.stub
stubs/runtime/
stubs/runtime/Enum/
stubs/ServiceDocumentRepository.stub
stubs/ServiceEntityRepository.stub
```

With this PR, the archive targets other than src/ will be as follows:
```bash
gh api repos/sasezaki/phpstan-doctrine/tarball/patch-gitattributes | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
composer.json
extension.neon
LICENSE
README.md
rules.neon
stubs/
stubs/Collections/
stubs/Collections/AbstractLazyCollection.stub
stubs/Collections/ArrayCollection.stub
stubs/Collections/Collection1.stub
stubs/Collections/Collection.stub
stubs/Collections/ReadableCollection1.stub
stubs/Collections/ReadableCollection.stub
stubs/Collections/Selectable.stub
stubs/Criteria.stub
stubs/DBAL/
stubs/DBAL/ArrayParameterType.stub
stubs/DBAL/Cache/
stubs/DBAL/Cache/CacheException.stub
stubs/DBAL/Cache/QueryCacheProfile.stub
stubs/DBAL/Connection4.stub
stubs/DBAL/Connection.stub
stubs/DBAL/Exception/
stubs/DBAL/Exception.stub
stubs/DBAL/Exception/UniqueConstraintViolationException.stub
stubs/DBAL/ParameterType.stub
stubs/DBAL/Result.stub
stubs/DBAL/Statement.stub
stubs/DBAL/Types/
stubs/DBAL/Types/Type.stub
stubs/DocumentManager.stub
stubs/DocumentRepository.stub
stubs/EntityManagerDecorator.stub
stubs/EntityManagerInterface.stub
stubs/EntityManager.stub
stubs/EntityRepository.stub
stubs/LazyServiceEntityRepository.stub
stubs/MongoClassMetadataInfo.stub
stubs/ORM/
stubs/ORM/AbstractQuery.stub
stubs/ORM/Exception/
stubs/ORM/Exception/ORMException.stub
stubs/ORM/Id/
stubs/ORM/Id/AbstractIdGenerator.stub
stubs/ORM/Mapping/
stubs/ORM/Mapping/ClassMetadataInfo.stub
stubs/ORM/Mapping/ClassMetadata.stub
stubs/ORM/Mapping/ManyToManyInverseSideMapping.stub
stubs/ORM/Mapping/ManyToManyOwningSideMapping.stub
stubs/ORM/Mapping/ManyToOneAssociationMapping.stub
stubs/ORM/Mapping/OneToManyAssociationMapping.stub
stubs/ORM/Mapping/OneToOneInverseSideMapping.stub
stubs/ORM/Mapping/OneToOneOwningSideMapping.stub
stubs/ORM/NonUniqueResultException.stub
stubs/ORM/NoResultException.stub
stubs/ORM/ORMException.stub
stubs/ORM/Query/
stubs/ORM/QueryBuilder.stub
stubs/ORM/Query/Expr/
stubs/ORM/Query/Expr/Comparison.stub
stubs/ORM/Query/Expr/Composite.stub
stubs/ORM/Query/Expr/Func.stub
stubs/ORM/Query/Expr/Join.stub
stubs/ORM/Query/Expr.stub
stubs/ORM/Query.stub
stubs/ORM/Tools/
stubs/ORM/Tools/Pagination/
stubs/ORM/Tools/Pagination/Paginator.stub
stubs/ORM/UnexpectedResultException.stub
stubs/Persistence/
stubs/Persistence/ManagerRegistry.stub
stubs/Persistence/Mapping/
stubs/Persistence/Mapping/ClassMetadata.stub
stubs/Persistence/ObjectManagerDecorator.stub
stubs/Persistence/ObjectManager.stub
stubs/Persistence/ObjectRepository.stub
stubs/RepositoryFactory.stub
stubs/runtime/
stubs/runtime/Enum/
stubs/ServiceDocumentRepository.stub
stubs/ServiceEntityRepository.stub
```

Changes:
- Added `collision-detector.json export-ignore`
  - `collision-detector.json`: A configuration file for the collision-detector dev tool; not needed by package consumers.
