### PR TITLE
latest infection does not support PHP 8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.2"
           - "8.3"
           - "8.4"
 


### PR DESCRIPTION
lets drop 8.2 builds (which we also do not run on phpstan-src).
that way we can raise the min php-version in build infection and get back to the most recent releases