### PR TITLE
Support Doctrine NumberType

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -374,6 +374,9 @@ services:
 		class: PHPStan\Type\Doctrine\Descriptors\JsonType
 		tags: [phpstan.doctrine.typeDescriptor]
 	-
+		class: PHPStan\Type\Doctrine\Descriptors\NumberType
+		tags: [phpstan.doctrine.typeDescriptor]
+	-
 		class: PHPStan\Type\Doctrine\Descriptors\ObjectType
 		tags: [phpstan.doctrine.typeDescriptor]
 	-

--- a/phpstan-baseline-dbal-4.neon
+++ b/phpstan-baseline-dbal-4.neon
@@ -31,6 +31,18 @@ parameters:
 			path: src/Type/Doctrine/Query/QueryResultTypeWalker.php
 
 		-
+			message: '#^Class Doctrine\\DBAL\\Types\\NumberType not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Type/Doctrine/Descriptors/NumberType.php
+
+		-
+			message: '#^Method PHPStan\\Type\\Doctrine\\Descriptors\\NumberType\:\:getType\(\) should return class\-string\<Doctrine\\DBAL\\Types\\Type\> but returns string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Type/Doctrine/Descriptors/NumberType.php
+
+		-
 			rawMessage: '''
 				Call to method __construct() of deprecated class Doctrine\ORM\Mapping\Driver\AnnotationDriver:
 				This class will be removed in 3.0 without replacement.

--- a/src/Type/Doctrine/Descriptors/NumberType.php
+++ b/src/Type/Doctrine/Descriptors/NumberType.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine\Descriptors;
+
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class NumberType implements DoctrineTypeDescriptor
+{
+
+	public function getType(): string
+	{
+		return \Doctrine\DBAL\Types\NumberType::class;
+	}
+
+	public function getWritableToPropertyType(): Type
+	{
+		return new ObjectType('BcMath\Number');
+	}
+
+	public function getWritableToDatabaseType(): Type
+	{
+		return new ObjectType('BcMath\Number');
+	}
+
+	public function getDatabaseInternalType(): Type
+	{
+		return (new ObjectType('BcMath\Number'))->toString();
+	}
+
+}

--- a/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
@@ -21,6 +21,7 @@ use PHPStan\Type\Doctrine\Descriptors\DecimalType;
 use PHPStan\Type\Doctrine\Descriptors\EnumType;
 use PHPStan\Type\Doctrine\Descriptors\IntegerType;
 use PHPStan\Type\Doctrine\Descriptors\JsonType;
+use PHPStan\Type\Doctrine\Descriptors\NumberType;
 use PHPStan\Type\Doctrine\Descriptors\Ramsey\UuidTypeDescriptor as RamseyUuidTypeDescriptor;
 use PHPStan\Type\Doctrine\Descriptors\ReflectionDescriptor;
 use PHPStan\Type\Doctrine\Descriptors\SimpleArrayType;
@@ -95,6 +96,7 @@ class EntityColumnRuleTest extends RuleTestCase
 				new DecimalType(new DriverDetector()),
 				new JsonType(),
 				new IntegerType(),
+				new NumberType(),
 				new StringType(),
 				new SimpleArrayType(),
 				new EnumType(),


### PR DESCRIPTION
Support Doctrine NumberType class that maps decimal values to BcMath\Number objects.

Requires PHP 8.4 and DBAL 4.3.0.

https://github.com/doctrine/dbal/pull/6686

Related issue https://github.com/phpstan/phpstan-doctrine/issues/753

Unsure how to test and deal with the PHP/DBAL version requirements though.