### PR TITLE
Support query inference with multiple entity managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ $kernel->boot();
 return $kernel->getContainer()->get('doctrine')->getManager();
 ```
 
+If your application uses multiple entity managers, return the Doctrine manager
+registry from the loader. PHPStan Doctrine will use it to pick the object manager
+that owns the entity being analysed:
+
+```php
+// tests/object-manager.php
+
+use App\Kernel;
+use Symfony\Component\Dotenv\Dotenv;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+(new Dotenv())->bootEnv(__DIR__ . '/../.env');
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel->boot();
+return $kernel->getContainer()->get('doctrine');
+```
+
 ## Query type inference
 
 This extension can infer the result type of DQL queries when an `objectManagerLoader` is provided.

--- a/src/Rules/Doctrine/ORM/DqlRule.php
+++ b/src/Rules/Doctrine/ORM/DqlRule.php
@@ -58,19 +58,16 @@ class DqlRule implements Rule
 			return [];
 		}
 
-		$objectManager = $this->objectMetadataResolver->getObjectManager();
-		if ($objectManager === null) {
-			return [];
-		}
-		if (!$objectManager instanceof $entityManagerInterface) {
-			return [];
-		}
-
-		/** @var EntityManagerInterface $objectManager */
-		$objectManager = $objectManager;
-
 		$messages = [];
 		foreach ($dqls as $dql) {
+			$objectManager = $this->objectMetadataResolver->getObjectManagerForDql($dql->getValue());
+			if (!$objectManager instanceof $entityManagerInterface) {
+				continue;
+			}
+
+			/** @var EntityManagerInterface $objectManager */
+			$objectManager = $objectManager;
+
 			$query = $objectManager->createQuery($dql->getValue());
 			try {
 				$query->getAST();

--- a/src/Rules/Doctrine/ORM/QueryBuilderDqlRule.php
+++ b/src/Rules/Doctrine/ORM/QueryBuilderDqlRule.php
@@ -92,21 +92,18 @@ class QueryBuilderDqlRule implements Rule
 			return [];
 		}
 
-		$objectManager = $this->objectMetadataResolver->getObjectManager();
-		if ($objectManager === null) {
-			return [];
-		}
-
 		$entityManagerInterface = 'Doctrine\ORM\EntityManagerInterface';
-		if (!$objectManager instanceof $entityManagerInterface) {
-			return [];
-		}
-
-		/** @var EntityManagerInterface $objectManager */
-		$objectManager = $objectManager;
 
 		$messages = [];
 		foreach ($dqls as $dql) {
+			$objectManager = $this->objectMetadataResolver->getObjectManagerForDql($dql->getValue());
+			if (!$objectManager instanceof $entityManagerInterface) {
+				continue;
+			}
+
+			/** @var EntityManagerInterface $objectManager */
+			$objectManager = $objectManager;
+
 			try {
 				$objectManager->createQuery($dql->getValue())->getAST();
 			} catch (QueryException $e) {

--- a/src/Type/Doctrine/CreateQueryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/CreateQueryDynamicReturnTypeExtension.php
@@ -89,7 +89,7 @@ final class CreateQueryDynamicReturnTypeExtension implements DynamicMethodReturn
 			if ($type instanceof ConstantStringType) {
 				$queryString = $type->getValue();
 
-				$em = $this->objectMetadataResolver->getObjectManager();
+				$em = $this->objectMetadataResolver->getObjectManagerForDql($queryString);
 				if (!$em instanceof EntityManagerInterface) {
 					return new QueryType($queryString, null, null);
 				}

--- a/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/GetRepositoryDynamicReturnTypeExtension.php
@@ -104,9 +104,10 @@ class GetRepositoryDynamicReturnTypeExtension implements DynamicMethodReturnType
 		}
 
 		$repositoryTypes = [];
+		$managerName = $this->getManagerName($scope, $methodCall->getArgs());
 		foreach ($objectNames as $objectName) {
 			try {
-				$repositoryClass = $this->getRepositoryClass($objectName, $defaultRepositoryClass);
+				$repositoryClass = $this->getRepositoryClass($objectName, $defaultRepositoryClass, $managerName);
 			} catch (\Doctrine\Persistence\Mapping\MappingException | MappingException | AnnotationException $e) {
 				return $this->getDefaultReturnType($scope, $methodCall->getArgs(), $methodReflection, $defaultRepositoryClass);
 			}
@@ -138,7 +139,24 @@ class GetRepositoryDynamicReturnTypeExtension implements DynamicMethodReturnType
 		return $defaultType;
 	}
 
-	private function getRepositoryClass(string $className, string $defaultRepositoryClass): string
+	/**
+	 * @param Arg[] $args
+	 */
+	private function getManagerName(Scope $scope, array $args): ?string
+	{
+		if (count($args) < 2) {
+			return null;
+		}
+
+		$managerNames = $scope->getType($args[1]->value)->getConstantStrings();
+		if (count($managerNames) !== 1) {
+			return null;
+		}
+
+		return $managerNames[0]->getValue();
+	}
+
+	private function getRepositoryClass(string $className, string $defaultRepositoryClass, ?string $managerName): string
 	{
 		if (!$this->reflectionProvider->hasClass($className)) {
 			return $defaultRepositoryClass;
@@ -149,12 +167,29 @@ class GetRepositoryDynamicReturnTypeExtension implements DynamicMethodReturnType
 			return $defaultRepositoryClass;
 		}
 
+		if ($managerName !== null) {
+			$objectManager = $this->metadataResolver->getObjectManagerByName($managerName);
+			if ($objectManager !== null) {
+				$metadata = $objectManager->getClassMetadata($classReflection->getName());
+				$odmMetadataClass = 'Doctrine\ODM\MongoDB\Mapping\ClassMetadata';
+				if ($metadata instanceof $odmMetadataClass) {
+					/** @var ClassMetadata<object> $odmMetadata */
+					$odmMetadata = $metadata;
+					return $odmMetadata->customRepositoryClassName ?? $defaultRepositoryClass;
+				}
+
+				if ($metadata instanceof \Doctrine\ORM\Mapping\ClassMetadata) {
+					return $metadata->customRepositoryClassName ?? $defaultRepositoryClass;
+				}
+			}
+		}
+
 		$metadata = $this->metadataResolver->getClassMetadata($classReflection->getName());
 		if ($metadata !== null) {
 			return $metadata->customRepositoryClassName ?? $defaultRepositoryClass;
 		}
 
-		$objectManager = $this->metadataResolver->getObjectManager();
+		$objectManager = $this->metadataResolver->getObjectManagerForClass($classReflection->getName());
 		if ($objectManager === null) {
 			return $defaultRepositoryClass;
 		}

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -20,6 +20,7 @@ use function is_file;
 use function is_readable;
 use function method_exists;
 use function preg_match_all;
+use function preg_replace;
 use function reset;
 use function sprintf;
 use const PHP_VERSION_ID;
@@ -100,8 +101,13 @@ final class ObjectMetadataResolver
 			return $objectManagerLoaderResult;
 		}
 
-		preg_match_all('~\b(?:FROM|UPDATE)\s+([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dql, $matches);
-		preg_match_all('~\bDELETE\s+(?:FROM\s+)?([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dql, $deleteMatches);
+		$dqlWithoutStringLiterals = preg_replace("~'(?:''|[^'])*'~", "''", $dql);
+		if ($dqlWithoutStringLiterals === null) {
+			$dqlWithoutStringLiterals = $dql;
+		}
+
+		preg_match_all('~\b(?:FROM|UPDATE)\s+([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dqlWithoutStringLiterals, $matches);
+		preg_match_all('~\bDELETE\s+(?:FROM\s+)?([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dqlWithoutStringLiterals, $deleteMatches);
 		foreach (array_merge($matches[1], $deleteMatches[1]) as $className) {
 			if (!class_exists($className)) {
 				continue;

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -14,10 +14,12 @@ use PHPStan\ShouldNotHappenException;
 use ReflectionException;
 use function array_merge;
 use function class_exists;
+use function count;
 use function is_file;
 use function is_readable;
 use function method_exists;
 use function preg_match_all;
+use function reset;
 use function sprintf;
 use const PHP_VERSION_ID;
 
@@ -68,7 +70,16 @@ final class ObjectMetadataResolver
 	public function getObjectManagerForClass(string $className): ?ObjectManager
 	{
 		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
+		if ($objectManagerLoaderResult instanceof ObjectManager) {
+			return $objectManagerLoaderResult;
+		}
+
 		if ($objectManagerLoaderResult instanceof ManagerRegistry) {
+			$singleObjectManager = $this->getSingleObjectManager($objectManagerLoaderResult);
+			if ($singleObjectManager !== null) {
+				return $singleObjectManager;
+			}
+
 			$objectManager = $objectManagerLoaderResult->getManagerForClass($className);
 			if ($objectManager instanceof ObjectManager) {
 				return $objectManager;
@@ -76,6 +87,20 @@ final class ObjectMetadataResolver
 		}
 
 		return $this->getObjectManager();
+	}
+
+	public function getObjectManagerByName(string $name): ?ObjectManager
+	{
+		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
+		if (!$objectManagerLoaderResult instanceof ManagerRegistry) {
+			return null;
+		}
+
+		try {
+			return $objectManagerLoaderResult->getManager($name);
+		} catch (\Throwable $e) {
+			return null;
+		}
 	}
 
 	public function getObjectManagerForDql(string $dql): ?ObjectManager
@@ -94,6 +119,17 @@ final class ObjectMetadataResolver
 		}
 
 		return $this->getObjectManager();
+	}
+
+	private function getSingleObjectManager(ManagerRegistry $managerRegistry): ?ObjectManager
+	{
+		$objectManagers = $managerRegistry->getManagers();
+		if (count($objectManagers) !== 1) {
+			return null;
+		}
+
+		$objectManager = reset($objectManagers);
+		return $objectManager;
 	}
 
 	/**

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -54,15 +54,11 @@ final class ObjectMetadataResolver
 	public function getObjectManager(): ?ObjectManager
 	{
 		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
-		if ($objectManagerLoaderResult instanceof ManagerRegistry) {
-			return $objectManagerLoaderResult->getManager();
-		}
-
-		if ($objectManagerLoaderResult instanceof ObjectManager) {
+		if (!$objectManagerLoaderResult instanceof ManagerRegistry) {
 			return $objectManagerLoaderResult;
 		}
 
-		return null;
+		return $objectManagerLoaderResult->getManager();
 	}
 
 	/**
@@ -71,20 +67,13 @@ final class ObjectMetadataResolver
 	public function getObjectManagerForClass(string $className): ?ObjectManager
 	{
 		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
-		if ($objectManagerLoaderResult instanceof ObjectManager) {
+		if (!$objectManagerLoaderResult instanceof ManagerRegistry) {
 			return $objectManagerLoaderResult;
 		}
 
-		if ($objectManagerLoaderResult instanceof ManagerRegistry) {
-			$singleObjectManager = $this->getSingleObjectManager($objectManagerLoaderResult);
-			if ($singleObjectManager !== null) {
-				return $singleObjectManager;
-			}
-
-			$objectManager = $objectManagerLoaderResult->getManagerForClass($className);
-			if ($objectManager instanceof ObjectManager) {
-				return $objectManager;
-			}
+		$objectManager = $objectManagerLoaderResult->getManagerForClass($className);
+		if ($objectManager instanceof ObjectManager) {
+			return $objectManager;
 		}
 
 		return $this->getObjectManager();
@@ -106,6 +95,11 @@ final class ObjectMetadataResolver
 
 	public function getObjectManagerForDql(string $dql): ?ObjectManager
 	{
+		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
+		if (!$objectManagerLoaderResult instanceof ManagerRegistry) {
+			return $objectManagerLoaderResult;
+		}
+
 		preg_match_all('~\b(?:FROM|UPDATE)\s+([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dql, $matches);
 		preg_match_all('~\bDELETE\s+(?:FROM\s+)?([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dql, $deleteMatches);
 		foreach (array_merge($matches[1], $deleteMatches[1]) as $className) {
@@ -113,23 +107,13 @@ final class ObjectMetadataResolver
 				continue;
 			}
 
-			$objectManager = $this->getObjectManagerForClass($className);
+			$objectManager = $objectManagerLoaderResult->getManagerForClass($className);
 			if ($objectManager !== null) {
 				return $objectManager;
 			}
 		}
 
 		return $this->getObjectManager();
-	}
-
-	private function getSingleObjectManager(ManagerRegistry $managerRegistry): ?ObjectManager
-	{
-		$objectManagers = $managerRegistry->getManagers();
-		if (count($objectManagers) !== 1) {
-			return null;
-		}
-
-		return reset($objectManagers);
 	}
 
 	/**
@@ -151,7 +135,15 @@ final class ObjectMetadataResolver
 			return null;
 		}
 
-		$this->objectManagerLoaderResult = $this->loadObjectManager($this->objectManagerLoader);
+		$objectManagerLoaderResult = $this->loadObjectManager($this->objectManagerLoader);
+		if ($objectManagerLoaderResult instanceof ManagerRegistry) {
+			$objectManagers = $objectManagerLoaderResult->getManagers();
+			if (count($objectManagers) === 1) {
+				$objectManagerLoaderResult = reset($objectManagers);
+			}
+		}
+
+		$this->objectManagerLoaderResult = $objectManagerLoaderResult;
 
 		return $this->objectManagerLoaderResult;
 	}

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -7,14 +7,17 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use PHPStan\Doctrine\Mapping\ClassMetadataFactory;
 use PHPStan\ShouldNotHappenException;
 use ReflectionException;
+use function array_merge;
 use function class_exists;
 use function is_file;
 use function is_readable;
 use function method_exists;
+use function preg_match_all;
 use function sprintf;
 use const PHP_VERSION_ID;
 
@@ -23,8 +26,8 @@ final class ObjectMetadataResolver
 
 	private ?string $objectManagerLoader = null;
 
-	/** @var ObjectManager|false|null */
-	private $objectManager;
+	/** @var ObjectManager|ManagerRegistry|false|null */
+	private $objectManagerLoaderResult;
 
 	private ?ClassMetadataFactory $metadataFactory = null;
 
@@ -47,23 +50,79 @@ final class ObjectMetadataResolver
 	/** @api */
 	public function getObjectManager(): ?ObjectManager
 	{
-		if ($this->objectManager === false) {
+		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
+		if ($objectManagerLoaderResult instanceof ManagerRegistry) {
+			$objectManager = $objectManagerLoaderResult->getManager();
+			if (!$objectManager instanceof ObjectManager) {
+				return null;
+			}
+
+			return $objectManager;
+		}
+
+		if ($objectManagerLoaderResult instanceof ObjectManager) {
+			return $objectManagerLoaderResult;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param class-string $className
+	 */
+	public function getObjectManagerForClass(string $className): ?ObjectManager
+	{
+		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
+		if ($objectManagerLoaderResult instanceof ManagerRegistry) {
+			$objectManager = $objectManagerLoaderResult->getManagerForClass($className);
+			if ($objectManager instanceof ObjectManager) {
+				return $objectManager;
+			}
+		}
+
+		return $this->getObjectManager();
+	}
+
+	public function getObjectManagerForDql(string $dql): ?ObjectManager
+	{
+		preg_match_all('~\b(?:FROM|UPDATE)\s+([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dql, $matches);
+		preg_match_all('~\bDELETE\s+(?:FROM\s+)?([\\\\A-Za-z_][\\\\A-Za-z0-9_]*)(?:\s+|$)~i', $dql, $deleteMatches);
+		foreach (array_merge($matches[1], $deleteMatches[1]) as $className) {
+			if (!class_exists($className)) {
+				continue;
+			}
+
+			$objectManager = $this->getObjectManagerForClass($className);
+			if ($objectManager !== null) {
+				return $objectManager;
+			}
+		}
+
+		return $this->getObjectManager();
+	}
+
+	/**
+	 * @return ObjectManager|ManagerRegistry|null
+	 */
+	private function getObjectManagerLoaderResult()
+	{
+		if ($this->objectManagerLoaderResult === false) {
 			return null;
 		}
 
-		if ($this->objectManager !== null) {
-			return $this->objectManager;
+		if ($this->objectManagerLoaderResult !== null) {
+			return $this->objectManagerLoaderResult;
 		}
 
 		if ($this->objectManagerLoader === null) {
-			$this->objectManager = false;
+			$this->objectManagerLoaderResult = false;
 
 			return null;
 		}
 
-		$this->objectManager = $this->loadObjectManager($this->objectManagerLoader);
+		$this->objectManagerLoaderResult = $this->loadObjectManager($this->objectManagerLoader);
 
-		return $this->objectManager;
+		return $this->objectManagerLoaderResult;
 	}
 
 	public function isNativeLazyObjectsEnabled(): bool
@@ -99,7 +158,7 @@ final class ObjectMetadataResolver
 			return true;
 		}
 
-		$objectManager = $this->getObjectManager();
+		$objectManager = $this->getObjectManagerForClass($className);
 
 		try {
 			if ($objectManager === null) {
@@ -143,7 +202,7 @@ final class ObjectMetadataResolver
 			return null;
 		}
 
-		$objectManager = $this->getObjectManager();
+		$objectManager = $this->getObjectManagerForClass($className);
 
 		try {
 			if ($objectManager === null) {
@@ -172,7 +231,10 @@ final class ObjectMetadataResolver
 		return $ormMetadata;
 	}
 
-	private function loadObjectManager(string $objectManagerLoader): ?ObjectManager
+	/**
+	 * @return ObjectManager|ManagerRegistry|null
+	 */
+	private function loadObjectManager(string $objectManagerLoader)
 	{
 		if (!is_file($objectManagerLoader)) {
 			throw new ShouldNotHappenException(sprintf(

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -52,12 +52,7 @@ final class ObjectMetadataResolver
 	{
 		$objectManagerLoaderResult = $this->getObjectManagerLoaderResult();
 		if ($objectManagerLoaderResult instanceof ManagerRegistry) {
-			$objectManager = $objectManagerLoaderResult->getManager();
-			if (!$objectManager instanceof ObjectManager) {
-				return null;
-			}
-
-			return $objectManager;
+			return $objectManagerLoaderResult->getManager();
 		}
 
 		if ($objectManagerLoaderResult instanceof ObjectManager) {

--- a/src/Type/Doctrine/ObjectMetadataResolver.php
+++ b/src/Type/Doctrine/ObjectMetadataResolver.php
@@ -12,6 +12,7 @@ use Doctrine\Persistence\ObjectManager;
 use PHPStan\Doctrine\Mapping\ClassMetadataFactory;
 use PHPStan\ShouldNotHappenException;
 use ReflectionException;
+use Throwable;
 use function array_merge;
 use function class_exists;
 use function count;
@@ -98,7 +99,7 @@ final class ObjectMetadataResolver
 
 		try {
 			return $objectManagerLoaderResult->getManager($name);
-		} catch (\Throwable $e) {
+		} catch (Throwable $e) {
 			return null;
 		}
 	}
@@ -128,8 +129,7 @@ final class ObjectMetadataResolver
 			return null;
 		}
 
-		$objectManager = reset($objectManagers);
-		return $objectManager;
+		return reset($objectManagers);
 	}
 
 	/**

--- a/src/Type/Doctrine/QueryBuilder/QueryBuilderGetQueryDynamicReturnTypeExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/QueryBuilderGetQueryDynamicReturnTypeExtension.php
@@ -191,7 +191,7 @@ class QueryBuilderGetQueryDynamicReturnTypeExtension implements DynamicMethodRet
 
 	private function getQueryType(string $dql): Type
 	{
-		$em = $this->objectMetadataResolver->getObjectManager();
+		$em = $this->objectMetadataResolver->getObjectManagerForDql($dql);
 		if (!$em instanceof EntityManagerInterface) {
 			return new QueryType($dql, null);
 		}

--- a/tests/Type/Doctrine/MultipleEntityManagersQueryTypeInferenceTest.php
+++ b/tests/Type/Doctrine/MultipleEntityManagersQueryTypeInferenceTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class MultipleEntityManagersQueryTypeInferenceTest extends TypeInferenceTestCase
+{
+
+	/** @return iterable<mixed> */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/QueryResult/multipleEntityManagers.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	/** @return string[] */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/data/QueryResult/config-multiple-entity-managers.neon'];
+	}
+
+}

--- a/tests/Type/Doctrine/NamedManagerRepositoryTypeInferenceTest.php
+++ b/tests/Type/Doctrine/NamedManagerRepositoryTypeInferenceTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class NamedManagerRepositoryTypeInferenceTest extends TypeInferenceTestCase
+{
+
+	/** @return iterable<mixed> */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/namedManagerRepository.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	/** @return string[] */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/data/named-manager-repository.neon'];
+	}
+
+}

--- a/tests/Type/Doctrine/ObjectMetadataResolverMultipleEntityManagersTest.php
+++ b/tests/Type/Doctrine/ObjectMetadataResolverMultipleEntityManagersTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine;
+
+use PHPUnit\Framework\TestCase;
+use QueryResult\MultipleEntityManagers\Main\User;
+use QueryResult\MultipleEntityManagers\Tenant\App;
+
+class ObjectMetadataResolverMultipleEntityManagersTest extends TestCase
+{
+
+	private ObjectMetadataResolver $resolver;
+
+	protected function setUp(): void
+	{
+		$this->resolver = new ObjectMetadataResolver(
+			__DIR__ . '/data/QueryResult/entity-manager-selection-registry.php',
+			__DIR__ . '/../../../tmp',
+		);
+	}
+
+	/**
+	 * @dataProvider dqlManagerProvider
+	 */
+	public function testSelectsObjectManagerFromDqlEntityClass(string $dql, string $managerName): void
+	{
+		self::assertSame(
+			$this->resolver->getObjectManagerByName($managerName),
+			$this->resolver->getObjectManagerForDql($dql),
+		);
+	}
+
+	/** @return iterable<string, array{string, string}> */
+	public static function dqlManagerProvider(): iterable
+	{
+		yield 'select with explicit AS alias' => [
+			'SELECT a FROM ' . App::class . ' AS a',
+			'tenant',
+		];
+
+		yield 'lowercase select keyword' => [
+			'select a from ' . App::class . ' a',
+			'tenant',
+		];
+
+		yield 'partial object select' => [
+			'SELECT PARTIAL a.{id} FROM ' . App::class . ' a',
+			'tenant',
+		];
+
+		yield 'root entity before subquery' => [
+			'SELECT u FROM ' . User::class . ' u WHERE u.id IN (SELECT a.id FROM ' . App::class . ' a)',
+			'default',
+		];
+
+		yield 'update query' => [
+			'UPDATE ' . App::class . ' a SET a.id = :id',
+			'tenant',
+		];
+
+		yield 'delete query with FROM' => [
+			'DELETE FROM ' . App::class . ' a',
+			'tenant',
+		];
+	}
+
+	public function testIgnoresClassLikeTextInsideDqlStringLiterals(): void
+	{
+		$dql = "SELECT 'FROM " . App::class . " a', 'DELETE FROM " . App::class . " a' FROM " . User::class . ' u';
+
+		self::assertSame(
+			$this->resolver->getObjectManagerByName('default'),
+			$this->resolver->getObjectManagerForDql($dql),
+		);
+	}
+
+	public function testIgnoresClassLikeTextInsideEscapedDqlStringLiterals(): void
+	{
+		$dql = "SELECT 'not '' FROM " . App::class . " a' FROM " . User::class . ' u';
+
+		self::assertSame(
+			$this->resolver->getObjectManagerByName('default'),
+			$this->resolver->getObjectManagerForDql($dql),
+		);
+	}
+
+}

--- a/tests/Type/Doctrine/data/QueryResult/EntitiesMultipleManagers/Main/User.php
+++ b/tests/Type/Doctrine/data/QueryResult/EntitiesMultipleManagers/Main/User.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace QueryResult\MultipleEntityManagers\Main;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+/**
+ * @Entity
+ */
+class User
+{
+
+	/**
+	 * @Column(type="integer")
+	 * @Id
+	 *
+	 * @var int
+	 */
+	public $id;
+
+}

--- a/tests/Type/Doctrine/data/QueryResult/EntitiesMultipleManagers/Tenant/App.php
+++ b/tests/Type/Doctrine/data/QueryResult/EntitiesMultipleManagers/Tenant/App.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace QueryResult\MultipleEntityManagers\Tenant;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+/**
+ * @Entity
+ */
+class App
+{
+
+	/**
+	 * @Column(type="integer")
+	 * @Id
+	 *
+	 * @var int
+	 */
+	public $id;
+
+}

--- a/tests/Type/Doctrine/data/QueryResult/config-multiple-entity-managers.neon
+++ b/tests/Type/Doctrine/data/QueryResult/config-multiple-entity-managers.neon
@@ -1,0 +1,6 @@
+includes:
+	- ../../../../../extension.neon
+	- ../../../../../rules.neon
+parameters:
+	doctrine:
+		objectManagerLoader: entity-manager-multiple.php

--- a/tests/Type/Doctrine/data/QueryResult/entity-manager-multiple.php
+++ b/tests/Type/Doctrine/data/QueryResult/entity-manager-multiple.php
@@ -107,6 +107,11 @@ return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
 		];
 	}
 
+	public function getAliasNamespace($alias)
+	{
+		throw new LogicException('Alias namespaces are not used in this test fixture.');
+	}
+
 	public function getRepository($persistentObject, $persistentManagerName = null)
 	{
 		return $this->getManager($persistentManagerName)->getRepository($persistentObject);

--- a/tests/Type/Doctrine/data/QueryResult/entity-manager-multiple.php
+++ b/tests/Type/Doctrine/data/QueryResult/entity-manager-multiple.php
@@ -7,8 +7,6 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Persistence\ObjectManager;
-use Doctrine\Persistence\ObjectRepository;
 
 $createEntityManager = static function (string $path): EntityManager {
 	$config = new Configuration();
@@ -53,7 +51,7 @@ return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
 		return 'default';
 	}
 
-	public function getConnection(?string $name = null)
+	public function getConnection($name = null)
 	{
 		return $this->getManager($name)->getConnection();
 	}
@@ -79,7 +77,7 @@ return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
 		return 'default';
 	}
 
-	public function getManager(?string $name = null)
+	public function getManager($name = null)
 	{
 		if ($name === 'tenant') {
 			return $this->tenantManager;
@@ -96,7 +94,7 @@ return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
 		];
 	}
 
-	public function resetManager(?string $name = null)
+	public function resetManager($name = null)
 	{
 		return $this->getManager($name);
 	}
@@ -109,12 +107,12 @@ return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
 		];
 	}
 
-	public function getRepository(string $persistentObject, ?string $persistentManagerName = null): ObjectRepository
+	public function getRepository($persistentObject, $persistentManagerName = null)
 	{
 		return $this->getManager($persistentManagerName)->getRepository($persistentObject);
 	}
 
-	public function getManagerForClass(string $class): ?ObjectManager
+	public function getManagerForClass($class)
 	{
 		foreach ($this->getManagers() as $manager) {
 			if (!$manager->getMetadataFactory()->isTransient($class)) {

--- a/tests/Type/Doctrine/data/QueryResult/entity-manager-multiple.php
+++ b/tests/Type/Doctrine/data/QueryResult/entity-manager-multiple.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types = 1);
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+
+$createEntityManager = static function (string $path): EntityManager {
+	$config = new Configuration();
+	$config->setProxyDir(__DIR__);
+	$config->setProxyNamespace('PHPstan\Doctrine\OrmProxies');
+	$config->setMetadataCache(new ArrayCachePool());
+	$config->setMetadataDriverImpl(new AnnotationDriver(
+		new AnnotationReader(),
+		[$path],
+	));
+
+	return new EntityManager(
+		DriverManager::getConnection([
+			'driver' => 'pdo_sqlite',
+			'memory' => true,
+		]),
+		$config,
+	);
+};
+
+$defaultManager = $createEntityManager(
+	__DIR__ . '/EntitiesMultipleManagers/Main',
+);
+$tenantManager = $createEntityManager(
+	__DIR__ . '/EntitiesMultipleManagers/Tenant',
+);
+
+return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
+
+	private EntityManager $defaultManager;
+
+	private EntityManager $tenantManager;
+
+	public function __construct(EntityManager $defaultManager, EntityManager $tenantManager)
+	{
+		$this->defaultManager = $defaultManager;
+		$this->tenantManager = $tenantManager;
+	}
+
+	public function getDefaultConnectionName()
+	{
+		return 'default';
+	}
+
+	public function getConnection(?string $name = null)
+	{
+		return $this->getManager($name)->getConnection();
+	}
+
+	public function getConnections()
+	{
+		return [
+			'default' => $this->defaultManager->getConnection(),
+			'tenant' => $this->tenantManager->getConnection(),
+		];
+	}
+
+	public function getConnectionNames()
+	{
+		return [
+			'default' => 'default',
+			'tenant' => 'tenant',
+		];
+	}
+
+	public function getDefaultManagerName()
+	{
+		return 'default';
+	}
+
+	public function getManager(?string $name = null)
+	{
+		if ($name === 'tenant') {
+			return $this->tenantManager;
+		}
+
+		return $this->defaultManager;
+	}
+
+	public function getManagers()
+	{
+		return [
+			'default' => $this->defaultManager,
+			'tenant' => $this->tenantManager,
+		];
+	}
+
+	public function resetManager(?string $name = null)
+	{
+		return $this->getManager($name);
+	}
+
+	public function getManagerNames()
+	{
+		return [
+			'default' => 'default',
+			'tenant' => 'tenant',
+		];
+	}
+
+	public function getRepository(string $persistentObject, ?string $persistentManagerName = null): ObjectRepository
+	{
+		return $this->getManager($persistentManagerName)->getRepository($persistentObject);
+	}
+
+	public function getManagerForClass(string $class): ?ObjectManager
+	{
+		foreach ($this->getManagers() as $manager) {
+			if (!$manager->getMetadataFactory()->isTransient($class)) {
+				return $manager;
+			}
+		}
+
+		return null;
+	}
+
+};

--- a/tests/Type/Doctrine/data/QueryResult/entity-manager-selection-registry.php
+++ b/tests/Type/Doctrine/data/QueryResult/entity-manager-selection-registry.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use QueryResult\MultipleEntityManagers\Main\User;
+use QueryResult\MultipleEntityManagers\Tenant\App;
+
+$createObjectManager = static function (): ObjectManager {
+	return new class () implements ObjectManager {
+
+		public function find(string $className, $id)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function persist(object $object)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function remove(object $object)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function clear()
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function detach(object $object)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function refresh(object $object)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function flush()
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function getRepository(string $className)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function getClassMetadata(string $className)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function getMetadataFactory()
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function initializeObject(object $obj)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function contains(object $object)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+	};
+};
+
+$defaultManager = $createObjectManager();
+$tenantManager = $createObjectManager();
+
+return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
+
+	private ObjectManager $defaultManager;
+
+	private ObjectManager $tenantManager;
+
+	public function __construct(ObjectManager $defaultManager, ObjectManager $tenantManager)
+	{
+		$this->defaultManager = $defaultManager;
+		$this->tenantManager = $tenantManager;
+	}
+
+	public function getDefaultConnectionName()
+	{
+		return 'default';
+	}
+
+	public function getConnection($name = null)
+	{
+		return new stdClass();
+	}
+
+	public function getConnections()
+	{
+		return [
+			'default' => new stdClass(),
+			'tenant' => new stdClass(),
+		];
+	}
+
+	public function getConnectionNames()
+	{
+		return [
+			'default' => 'default',
+			'tenant' => 'tenant',
+		];
+	}
+
+	public function getDefaultManagerName()
+	{
+		return 'default';
+	}
+
+	public function getManager($name = null)
+	{
+		if ($name === 'tenant') {
+			return $this->tenantManager;
+		}
+
+		return $this->defaultManager;
+	}
+
+	public function getManagers()
+	{
+		return [
+			'default' => $this->defaultManager,
+			'tenant' => $this->tenantManager,
+		];
+	}
+
+	public function resetManager($name = null)
+	{
+		return $this->getManager($name);
+	}
+
+	public function getManagerNames()
+	{
+		return [
+			'default' => 'default',
+			'tenant' => 'tenant',
+		];
+	}
+
+	public function getRepository($persistentObject, $persistentManagerName = null)
+	{
+		throw new LogicException('Not used by this fixture.');
+	}
+
+	public function getManagerForClass($class)
+	{
+		if ($class === App::class) {
+			return $this->tenantManager;
+		}
+
+		if ($class === User::class) {
+			return $this->defaultManager;
+		}
+
+		return null;
+	}
+
+};

--- a/tests/Type/Doctrine/data/QueryResult/entity-manager-selection-registry.php
+++ b/tests/Type/Doctrine/data/QueryResult/entity-manager-selection-registry.php
@@ -8,32 +8,37 @@ use QueryResult\MultipleEntityManagers\Tenant\App;
 $createObjectManager = static function (): ObjectManager {
 	return new class () implements ObjectManager {
 
-		public function find(string $className, $id)
+		public function find($className, $id)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function persist(object $object)
+		public function persist($object)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function remove(object $object)
+		public function remove($object)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function clear()
+		public function merge($object)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function detach(object $object)
+		public function clear($objectName = null)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function refresh(object $object)
+		public function detach($object)
+		{
+			throw new LogicException('Not used by this fixture.');
+		}
+
+		public function refresh($object)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
@@ -43,12 +48,12 @@ $createObjectManager = static function (): ObjectManager {
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function getRepository(string $className)
+		public function getRepository($className)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function getClassMetadata(string $className)
+		public function getClassMetadata($className)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
@@ -58,12 +63,12 @@ $createObjectManager = static function (): ObjectManager {
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function initializeObject(object $obj)
+		public function initializeObject($obj)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
 
-		public function contains(object $object)
+		public function contains($object)
 		{
 			throw new LogicException('Not used by this fixture.');
 		}
@@ -145,6 +150,11 @@ return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
 			'default' => 'default',
 			'tenant' => 'tenant',
 		];
+	}
+
+	public function getAliasNamespace($alias)
+	{
+		throw new LogicException('Alias namespaces are not used in this test fixture.');
 	}
 
 	public function getRepository($persistentObject, $persistentManagerName = null)

--- a/tests/Type/Doctrine/data/QueryResult/multipleEntityManagers.php
+++ b/tests/Type/Doctrine/data/QueryResult/multipleEntityManagers.php
@@ -56,4 +56,18 @@ class MultipleEntityManagers
 		assertType('Doctrine\ORM\Query<void, void>', $query);
 	}
 
+	public function directTenantDeleteWithFrom(EntityManagerInterface $entityManager): void
+	{
+		$query = $entityManager->createQuery('DELETE FROM QueryResult\MultipleEntityManagers\Tenant\App a');
+
+		assertType('Doctrine\ORM\Query<void, void>', $query);
+	}
+
+	public function directTenantUpdate(EntityManagerInterface $entityManager): void
+	{
+		$query = $entityManager->createQuery('UPDATE QueryResult\MultipleEntityManagers\Tenant\App a SET a.id = :id');
+
+		assertType('Doctrine\ORM\Query<void, void>', $query);
+	}
+
 }

--- a/tests/Type/Doctrine/data/QueryResult/multipleEntityManagers.php
+++ b/tests/Type/Doctrine/data/QueryResult/multipleEntityManagers.php
@@ -49,4 +49,11 @@ class MultipleEntityManagers
 		assertType('list<QueryResult\MultipleEntityManagers\Main\User>', $query->getResult());
 	}
 
+	public function directTenantDelete(EntityManagerInterface $entityManager): void
+	{
+		$query = $entityManager->createQuery('DELETE QueryResult\MultipleEntityManagers\Tenant\App a');
+
+		assertType('Doctrine\ORM\Query<void, void>', $query);
+	}
+
 }

--- a/tests/Type/Doctrine/data/QueryResult/multipleEntityManagers.php
+++ b/tests/Type/Doctrine/data/QueryResult/multipleEntityManagers.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace QueryResult\MultipleEntityManagers;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use QueryResult\MultipleEntityManagers\Main\User;
+use QueryResult\MultipleEntityManagers\Tenant\App;
+use function PHPStan\Testing\assertType;
+
+class MultipleEntityManagers
+{
+
+	/**
+	 * @param EntityRepository<User> $repository
+	 */
+	public function userRepository(EntityRepository $repository): void
+	{
+		$query = $repository->createQueryBuilder('u')->getQuery();
+
+		assertType('Doctrine\ORM\Query<null, QueryResult\MultipleEntityManagers\Main\User>', $query);
+		assertType('list<QueryResult\MultipleEntityManagers\Main\User>', $query->getResult());
+	}
+
+	/**
+	 * @param EntityRepository<App> $repository
+	 */
+	public function tenantRepository(EntityRepository $repository): void
+	{
+		$query = $repository->createQueryBuilder('a')->getQuery();
+
+		assertType('Doctrine\ORM\Query<null, QueryResult\MultipleEntityManagers\Tenant\App>', $query);
+		assertType('list<QueryResult\MultipleEntityManagers\Tenant\App>', $query->getResult());
+	}
+
+	public function directTenantQuery(EntityManagerInterface $entityManager): void
+	{
+		$query = $entityManager->createQuery('SELECT a FROM QueryResult\MultipleEntityManagers\Tenant\App a');
+
+		assertType('Doctrine\ORM\Query<null, QueryResult\MultipleEntityManagers\Tenant\App>', $query);
+		assertType('list<QueryResult\MultipleEntityManagers\Tenant\App>', $query->getResult());
+	}
+
+	public function directDefaultQuery(EntityManagerInterface $entityManager): void
+	{
+		$query = $entityManager->createQuery('SELECT u FROM QueryResult\MultipleEntityManagers\Main\User u');
+
+		assertType('Doctrine\ORM\Query<null, QueryResult\MultipleEntityManagers\Main\User>', $query);
+		assertType('list<QueryResult\MultipleEntityManagers\Main\User>', $query->getResult());
+	}
+
+}

--- a/tests/Type/Doctrine/data/named-manager-registry.php
+++ b/tests/Type/Doctrine/data/named-manager-registry.php
@@ -1,0 +1,205 @@
+<?php declare(strict_types = 1);
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+use NamedManagerRepositoryInference\DefaultSharedRepository;
+use NamedManagerRepositoryInference\SharedEntity;
+use NamedManagerRepositoryInference\TenantSharedRepository;
+
+require_once __DIR__ . '/namedManagerRepository.php';
+
+$createManager = static function (string $repositoryClass): ObjectManager {
+	$metadata = new ClassMetadata(SharedEntity::class);
+	$metadata->customRepositoryClassName = $repositoryClass;
+
+	$metadataFactory = new class ($metadata) implements ClassMetadataFactory {
+
+		private ClassMetadata $metadata;
+
+		public function __construct(ClassMetadata $metadata)
+		{
+			$this->metadata = $metadata;
+		}
+
+		public function getAllMetadata()
+		{
+			return [$this->metadata];
+		}
+
+		public function getMetadataFor($className)
+		{
+			return $this->metadata;
+		}
+
+		public function hasMetadataFor($className)
+		{
+			return $className === SharedEntity::class;
+		}
+
+		public function setMetadataFor($className, $class)
+		{
+		}
+
+		public function isTransient($className)
+		{
+			return $className !== SharedEntity::class;
+		}
+
+	};
+
+	return new class ($metadata, $metadataFactory) implements ObjectManager {
+
+		private ClassMetadata $metadata;
+
+		private ClassMetadataFactory $metadataFactory;
+
+		public function __construct(ClassMetadata $metadata, ClassMetadataFactory $metadataFactory)
+		{
+			$this->metadata = $metadata;
+			$this->metadataFactory = $metadataFactory;
+		}
+
+		public function find($className, $id)
+		{
+			return null;
+		}
+
+		public function persist($object)
+		{
+		}
+
+		public function remove($object)
+		{
+		}
+
+		public function clear($objectName = null)
+		{
+		}
+
+		public function detach($object)
+		{
+		}
+
+		public function refresh($object)
+		{
+		}
+
+		public function flush()
+		{
+		}
+
+		public function getRepository($className)
+		{
+			throw new LogicException('Repository instances are not needed by this type inference fixture.');
+		}
+
+		public function getClassMetadata($className)
+		{
+			return $this->metadata;
+		}
+
+		public function getMetadataFactory()
+		{
+			return $this->metadataFactory;
+		}
+
+		public function initializeObject($obj)
+		{
+		}
+
+		public function contains($object)
+		{
+			return false;
+		}
+
+	};
+};
+
+$defaultManager = $createManager(DefaultSharedRepository::class);
+$tenantManager = $createManager(TenantSharedRepository::class);
+
+return new class ($defaultManager, $tenantManager) implements ManagerRegistry {
+
+	private ObjectManager $defaultManager;
+
+	private ObjectManager $tenantManager;
+
+	public function __construct(ObjectManager $defaultManager, ObjectManager $tenantManager)
+	{
+		$this->defaultManager = $defaultManager;
+		$this->tenantManager = $tenantManager;
+	}
+
+	public function getDefaultConnectionName()
+	{
+		return 'default';
+	}
+
+	public function getConnection($name = null)
+	{
+		throw new LogicException('Connections are not used in this type inference fixture.');
+	}
+
+	public function getConnections()
+	{
+		return [];
+	}
+
+	public function getConnectionNames()
+	{
+		return [];
+	}
+
+	public function getDefaultManagerName()
+	{
+		return 'default';
+	}
+
+	public function getManager($name = null)
+	{
+		if ($name === 'tenant') {
+			return $this->tenantManager;
+		}
+
+		return $this->defaultManager;
+	}
+
+	public function getManagers()
+	{
+		return [
+			'default' => $this->defaultManager,
+			'tenant' => $this->tenantManager,
+		];
+	}
+
+	public function resetManager($name = null)
+	{
+		return $this->getManager($name);
+	}
+
+	public function getManagerNames()
+	{
+		return [
+			'default' => 'default',
+			'tenant' => 'tenant',
+		];
+	}
+
+	public function getRepository($persistentObject, $persistentManagerName = null)
+	{
+		return $this->getManager($persistentManagerName)->getRepository($persistentObject);
+	}
+
+	public function getManagerForClass($class)
+	{
+		return $class === SharedEntity::class ? $this->defaultManager : null;
+	}
+
+	public function getAliasNamespace($alias)
+	{
+		throw new LogicException('Alias namespaces are not used in this type inference fixture.');
+	}
+
+};

--- a/tests/Type/Doctrine/data/named-manager-registry.php
+++ b/tests/Type/Doctrine/data/named-manager-registry.php
@@ -70,6 +70,11 @@ $createManager = static function (string $repositoryClass): ObjectManager {
 		{
 		}
 
+		public function merge($object)
+		{
+			return $object;
+		}
+
 		public function remove($object)
 		{
 		}

--- a/tests/Type/Doctrine/data/named-manager-repository.neon
+++ b/tests/Type/Doctrine/data/named-manager-repository.neon
@@ -1,0 +1,5 @@
+includes:
+	- ../../../../extension.neon
+parameters:
+	doctrine:
+		objectManagerLoader: named-manager-registry.php

--- a/tests/Type/Doctrine/data/namedManagerRepository.php
+++ b/tests/Type/Doctrine/data/namedManagerRepository.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace NamedManagerRepositoryInference;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use function PHPStan\Testing\assertType;
+
+class Example
+{
+
+	public function explicitManagerName(ManagerRegistry $registry): void
+	{
+		assertType(DefaultSharedRepository::class . '<' . SharedEntity::class . '>', $registry->getRepository(SharedEntity::class, 'default'));
+		assertType(TenantSharedRepository::class . '<' . SharedEntity::class . '>', $registry->getRepository(SharedEntity::class, 'tenant'));
+	}
+
+}
+
+class SharedEntity
+{
+
+}
+
+/**
+ * @template T of object
+ * @extends EntityRepository<T>
+ */
+class DefaultSharedRepository extends EntityRepository
+{
+
+}
+
+/**
+ * @template T of object
+ * @extends EntityRepository<T>
+ */
+class TenantSharedRepository extends EntityRepository
+{
+
+}


### PR DESCRIPTION
## Summary

Fixes return type inference for projects that use multiple Doctrine entity managers by allowing `objectManagerLoader` to return a Doctrine `ManagerRegistry`.

When the loader returns a registry, PHPStan Doctrine now resolves the object manager from the entity class found in the DQL before validating or inferring query result types. This keeps the existing single-manager loader behavior intact while supporting Symfony applications where each entity namespace is owned by a different manager.

## Details

- Add `ManagerRegistry` support to `ObjectMetadataResolver`.
- Resolve entity metadata and DQL/query-builder analysis through `getManagerForClass()` when possible.
- Add a regression fixture with two in-memory entity managers mapped to disjoint namespaces.
- Document returning the Doctrine registry from Symfony `objectManagerLoader` setups.

## Verification

- `vendor/bin/phpunit`
- Verified the repro from #655 by returning the Symfony Doctrine registry from `objectManagerLoader` and running PHPStan against `tedyno/phpstan-multiple-em-issue`; it reports no errors with this branch.

Fixes #655
