### PR TITLE
Update ServiceEntityRepository stub

### DIFF
--- a/stubs/ServiceEntityRepository.stub
+++ b/stubs/ServiceEntityRepository.stub
@@ -1,11 +1,73 @@
 <?php
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
-use \Doctrine\ORM\EntityRepository;
+use Doctrine\Common\Collections\AbstractLazyCollection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 
 /**
  * @template T of object
  * @template-extends EntityRepository<T>
  */
-class ServiceEntityRepository extends EntityRepository {
+class ServiceEntityRepository extends EntityRepository
+{
+
+	/**
+	 * @phpstan-param mixed $id
+	 * @phpstan-param int|null $lockMode
+	 * @phpstan-param int|null $lockVersion
+	 * @phpstan-return T|null
+	 * @phpstan-impure
+	 */
+	public function find($id, $lockMode = null, $lockVersion = null);
+
+	/**
+	 * @phpstan-param array<string, mixed> $criteria
+	 * @phpstan-param array<string, string>|null $orderBy
+	 * @phpstan-param int|null $limit
+	 * @phpstan-param int|null $offset
+	 * @phpstan-return list<T>
+	 * @phpstan-impure
+	 */
+	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
+
+	/**
+	 * @phpstan-param array<string, mixed> $criteria The criteria.
+	 * @phpstan-param array<string, string>|null $orderBy
+	 * @phpstan-return T|null
+	 * @phpstan-impure
+	 */
+	public function findOneBy(array $criteria, ?array $orderBy = null);
+
+	/**
+	 * @phpstan-return class-string<T>
+	 */
+	protected function getEntityName();
+
+	/**
+	 * @param Criteria $criteria
+	 *
+	 * @phpstan-return AbstractLazyCollection<int, T>&Selectable<int, T>
+	 */
+	public function matching(Criteria $criteria);
+
+	/**
+	 * @param __doctrine-literal-string      $alias
+	 * @param __doctrine-literal-string|null $indexBy
+	 *
+	 * @return QueryBuilder
+	 */
+	public function createQueryBuilder($alias, $indexBy = null);
+
+	/**
+	 * @param array<string, mixed> $criteria
+	 *
+	 * @return int<0, max>
+	 *
+	 * @phpstan-impure
+	 */
+	public function count(array $criteria);
+
 }


### PR DESCRIPTION
Add new methods in doctrine/doctrine-bundle v3.

In doctrine/doctrine-bundle 2.x, PHPStan reports that Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository::findBy() returns list<Entity> but in 3.x, PHPStan reports that it returns array<int, Entity>.