### PR TITLE
Fix duplicate registration of RepositoryMethodCallRule

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -20,7 +20,6 @@ parametersSchema:
 
 rules:
 	- PHPStan\Rules\Doctrine\ORM\DqlRule
-	- PHPStan\Rules\Doctrine\ORM\RepositoryMethodCallRule
 	- PHPStan\Rules\Doctrine\ORM\EntityConstructorNotFinalRule
 	- PHPStan\Rules\Doctrine\ORM\EntityMappingExceptionRule
 	- PHPStan\Rules\Doctrine\ORM\EntityNotFinalRule

--- a/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-0.json
+++ b/tests/DoctrineIntegration/ORM/data/entityRepositoryDynamicReturn-0.json
@@ -5,16 +5,6 @@
         "ignorable": true
     },
     {
-        "message": "Call to method Doctrine\\ORM\\EntityRepository<PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity>::findOneBy() - entity PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity does not have a field named $blah.",
-        "line": 94,
-        "ignorable": true
-    },
-    {
-        "message": "Call to method Doctrine\\ORM\\EntityRepository<PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity>::findBy() - entity PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity does not have a field named $blah.",
-        "line": 116,
-        "ignorable": true
-    },
-    {
         "message": "Call to method Doctrine\\ORM\\EntityRepository<PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity>::findBy() - entity PHPStan\\DoctrineIntegration\\ORM\\EntityRepositoryDynamicReturn\\MyEntity does not have a field named $blah.",
         "line": 116,
         "ignorable": true


### PR DESCRIPTION
## Problem

`RepositoryMethodCallRule` is currently registered **twice** in `rules.neon`:

1. In the `rules:` section (autowired, so `checkOrderByFields` defaults to `false`):
   ```neon
   rules:
       - PHPStan\Rules\Doctrine\ORM\RepositoryMethodCallRule
   ```
2. As a tagged service in `services:`, wiring `checkOrderByFields` to the bleeding-edge toggle:
   ```neon
   services:
       -
           class: PHPStan\Rules\Doctrine\ORM\RepositoryMethodCallRule
           arguments:
               checkOrderByFields: %featureToggles.bleedingEdge%
           tags:
               - phpstan.rules.rule
   ```

Both registrations carry the `phpstan.rules.rule` tag, so PHPStan instantiates and runs the rule twice. As a result every magic `findBy*` / `findOneBy*` violation is reported as a **duplicate error**.

The `services:` entry was added in 5485522 ("Check field names of orderBy parameter in findBy and findOneBy"), while the `rules:` entry already existed — making the `rules:` line a stray duplicate. The same commit also updated the `entityRepositoryDynamicReturn-0.json` integration fixture to *expect* the doubled output, which hid the regression.

## Fix

- Remove the `rules:` entry and keep only the `services:` registration, which is the intended one since it wires the `checkOrderByFields` toggle.
- Restore the `entityRepositoryDynamicReturn-0.json` fixture so each `findOneBy()` / `findBy()` error is expected once.

Co-Authored-By: Claude Code