### PR TITLE
Sync ObjectRepository stub types with Doctrine

### DIFF
--- a/stubs/DocumentRepository.stub
+++ b/stubs/DocumentRepository.stub
@@ -21,17 +21,18 @@ class DocumentRepository implements ObjectRepository
 	public function find($id, $lockMode = null, $lockVersion = null);
 
 	/**
-	 * @phpstan-return array<int, TDocumentClass>
+	 * @phpstan-return list<TDocumentClass>
 	 * @phpstan-impure
 	 */
 	public function findAll();
 
 	/**
-	 * @phpstan-param array<string, mixed> $criteria
+	 * @phpstan-param array<string, string> $criteria
 	 * @phpstan-param array<string, string>|null $sort
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $skip
 	 * @phpstan-return array<int, TDocumentClass>
+	 * @phpstan-return list<TDocumentClass>
 	 * @phpstan-impure
 	 */
 	public function findBy(array $criteria, ?array $sort = null, $limit = null, $skip = null);

--- a/stubs/Persistence/ObjectRepository.stub
+++ b/stubs/Persistence/ObjectRepository.stub
@@ -15,16 +15,16 @@ interface ObjectRepository
 	public function find($id);
 
 	/**
-	 * @phpstan-return array<int, T>
+	 * @phpstan-return list<T>
 	 */
 	public function findAll();
 
 	/**
-	 * @phpstan-param array<string, mixed> $criteria
-	 * @phpstan-param array<string, string>|null $orderBy
+	 * @phpstan-param array<string, string> $criteria
+	 * @phpstan-param array<string, 'asc'|'desc'|'ASC'|'DESC'>|null $orderBy
 	 * @phpstan-param int|null $limit
 	 * @phpstan-param int|null $offset
-	 * @phpstan-return array<int, T>
+	 * @phpstan-return list<T>
 	 */
 	public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
 

--- a/tests/DoctrineIntegration/ODM/data/documentRepositoryDynamicReturn.php
+++ b/tests/DoctrineIntegration/ODM/data/documentRepositoryDynamicReturn.php
@@ -52,7 +52,7 @@ class Example
 	public function findAllDynamicType(): void
 	{
 		$items = $this->repository->findAll();
-		assertType('array<int, object>', $items);
+		assertType('list<object>', $items);
 
 		foreach ($items as $test) {
 			$test->doSomething();
@@ -63,7 +63,7 @@ class Example
 	public function findByDynamicType(): void
 	{
 		$items = $this->repository->findBy(['blah' => 'testing']);
-		assertType('array<int, object>', $items);
+		assertType('list<object>', $items);
 
 		foreach ($items as $test) {
 			$test->doSomething();
@@ -115,7 +115,7 @@ class Example2
 	public function findAllDynamicType(): void
 	{
 		$items = $this->repository->findAll();
-		assertType('array<int, ' . MyDocument::class . '>', $items);
+		assertType('list<' . MyDocument::class . '>', $items);
 
 		foreach ($items as $test) {
 			$test->doSomething();
@@ -126,7 +126,7 @@ class Example2
 	public function findByDynamicType(): void
 	{
 		$items = $this->repository->findBy(['blah' => 'testing']);
-		assertType('array<int, ' . MyDocument::class . '>', $items);
+		assertType('list<' . MyDocument::class . '>', $items);
 
 		foreach ($items as $test) {
 			$test->doSomething();


### PR DESCRIPTION
Refs: https://github.com/phpstan/phpstan/discussions/14802

See https://github.com/doctrine/persistence/blob/4.2.x/src/ObjectRepository.php

no clue if this file is even being needed still, maybe for older versions of Doctrine?

looks like they changed it to a list just recently, see https://github.com/doctrine/persistence/commit/d2ab8e3e36f2989c9ee9e9ec0a916e84551c5cd6

there's also open https://github.com/phpstan/phpstan-doctrine/pull/762 which might be trying to fix the same thing