### PR TITLE
Avoid reporting always true switch

### DIFF
--- a/src/Type/Doctrine/Query/QueryResultTypeWalker.php
+++ b/src/Type/Doctrine/Query/QueryResultTypeWalker.php
@@ -1577,6 +1577,7 @@ class QueryResultTypeWalker extends SqlWalker
 	 */
 	public function walkLiteral($literal): string
 	{
+		$type = new MixedType();
 		switch ($literal->type) {
 			case AST\Literal::STRING:
 				$value = $literal->value;
@@ -1623,10 +1624,6 @@ class QueryResultTypeWalker extends SqlWalker
 					}
 				}
 
-				break;
-
-			default:
-				$type = new MixedType();
 				break;
 		}
 


### PR DESCRIPTION
This is as-safe as the previous way but without the always true case error I think