### PR TITLE
Fix doctrine.columnType false positive for single table inheritance

### DIFF
--- a/src/Rules/Doctrine/ORM/EntityColumnRule.php
+++ b/src/Rules/Doctrine/ORM/EntityColumnRule.php
@@ -192,9 +192,20 @@ class EntityColumnRule implements Rule
 		}
 
 		$nullable = isset($fieldMapping['nullable']) ? $fieldMapping['nullable'] === true : false;
-		if ($nullable) {
-			$writableToPropertyType = TypeCombinator::addNull($writableToPropertyType);
+
+		// In single table inheritance, the database columns of child entities are always nullable,
+		// because the column is shared with the rest of the hierarchy that does not have the field set
+		// (see Doctrine\ORM\Tools\SchemaTool::gatherColumn). The property itself, however, may stay
+		// non-nullable, so the forced database nullability must not be required on the property side.
+		$nullabilityForcedBySingleTableInheritance = $metadata->isInheritanceTypeSingleTable()
+			&& $metadata->parentClasses !== []
+			&& !isset($fieldMapping['inherited']);
+
+		if ($nullable || $nullabilityForcedBySingleTableInheritance) {
 			$writableToDatabaseType = TypeCombinator::addNull($writableToDatabaseType);
+		}
+		if ($nullable && !$nullabilityForcedBySingleTableInheritance) {
+			$writableToPropertyType = TypeCombinator::addNull($writableToPropertyType);
 		}
 
 		$phpDocType = $node->getPhpDocType();

--- a/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
@@ -551,6 +551,26 @@ class EntityColumnRuleTest extends RuleTestCase
 	/**
 	 * @dataProvider dataObjectManagerLoader
 	 */
+	public function testSingleTableInheritance(?string $objectManagerLoader): void
+	{
+		$this->allowNullablePropertyForRequiredField = false;
+		$this->objectManagerLoader = $objectManagerLoader;
+
+		$this->analyse([__DIR__ . '/data/single-table-inheritance.php'], [
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\SingleTableInheritance\ChildEntity::$childBrokenColumn type mapping mismatch: database can contain string but property expects int.',
+				69,
+			],
+			[
+				'Property PHPStan\Rules\Doctrine\ORM\SingleTableInheritance\ChildEntity::$childBrokenColumn type mapping mismatch: property can contain int but database expects string|null.',
+				69,
+			],
+		]);
+	}
+
+	/**
+	 * @dataProvider dataObjectManagerLoader
+	 */
 	public function testBug659(?string $objectManagerLoader): void
 	{
 		$this->allowNullablePropertyForRequiredField = false;

--- a/tests/Rules/Doctrine/ORM/data/single-table-inheritance.php
+++ b/tests/Rules/Doctrine/ORM/data/single-table-inheritance.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Doctrine\ORM\SingleTableInheritance;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="discr", type="string")
+ * @ORM\DiscriminatorMap({
+ *  "base"="PHPStan\Rules\Doctrine\ORM\SingleTableInheritance\BaseEntity",
+ *  "child"="PHPStan\Rules\Doctrine\ORM\SingleTableInheritance\ChildEntity"
+ * })
+ */
+class BaseEntity
+{
+
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * @ORM\Column(type="string")
+	 *
+	 * @var string
+	 */
+	private $baseColumn;
+
+}
+
+/**
+ * @ORM\Entity()
+ */
+class ChildEntity extends BaseEntity
+{
+
+	/**
+	 * The column must be nullable in the database because it is shared with the rest of the
+	 * single table inheritance hierarchy, but the property itself is always set.
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 *
+	 * @var string
+	 */
+	private $childColumn;
+
+	/**
+	 * Nullable property is fine too.
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 *
+	 * @var string|null
+	 */
+	private $childNullableColumn;
+
+	/**
+	 * Genuine type mismatches in child entities are still reported.
+	 *
+	 * @ORM\Column(type="string", nullable=true)
+	 *
+	 * @var int
+	 */
+	private $childBrokenColumn;
+
+}


### PR DESCRIPTION
## Problem

The `doctrine.columnType` rule reports a false positive for child entities in a **Single Table Inheritance** hierarchy.

In STI, Doctrine's `SchemaTool::gatherColumn()` [forces every child-entity column to be nullable](https://github.com/doctrine/orm/blob/ed636b71ef3778aa52e6e6eba44f68d55f54c177/src/Tools/SchemaTool.php#L571-L573) in the database:

```php
$options['notnull'] = isset($mapping['nullable']) ? ! $mapping['nullable'] : true;
if ($class->isInheritanceTypeSingleTable() && $class->parentClasses) {
    $options['notnull'] = false;
}
```

This is required because the column is physically shared with the rest of the hierarchy, whose other rows do not set the field. So the user is obliged to declare `nullable: true`, even though the property is always set for that particular child and is correctly typed non-nullable:

```php
#[Entity]
#[InheritanceType('SINGLE_TABLE')]
#[DiscriminatorColumn(name: 'discr', type: 'string')]
#[DiscriminatorMap([...])]
class Author { /* ... */ }

#[Entity]
class AiModel extends Author
{
    // nullable in DB only because STI children share the author table
    #[Column(type: Types::TEXT, nullable: true)]
    private string $model; // always set for an AiModel
}
```

Previously this produced:

> Property `AiModel::$model` type mapping mismatch: database can contain `string|null` but property expects `string`.

## Fix

When a field's database nullability is forced purely by single table inheritance, the rule still treats the **database** type as nullable (the column genuinely is), but no longer requires the **property** to accept `null`. The detection mirrors `SchemaTool`'s own condition (`isInheritanceTypeSingleTable() && parentClasses`) and excludes inherited fields, which are validated on their declaring root class where columns are not forced nullable.

Genuine type mismatches in child entities are still reported.

## Tests

Added `testSingleTableInheritance` with a fixture covering:
- non-nullable property on a nullable STI child column → no error
- nullable property on a nullable STI child column → no error
- a genuinely mistyped child column → still reported (both directions)

Runs against both the `objectManagerLoader` and the standalone metadata paths.