### PR TITLE
Add a check for string-backed enum maximum length 

### DIFF
--- a/src/Rules/Doctrine/ORM/EntityColumnRule.php
+++ b/src/Rules/Doctrine/ORM/EntityColumnRule.php
@@ -120,6 +120,20 @@ class EntityColumnRule implements Rule
 								$enumReflection->getDisplayName(),
 								$writableToDatabaseType->describe(VerbosityLevel::typeOnly()),
 							))->identifier('doctrine.enumType')->build();
+						} elseif ($backedEnumType->isString()->yes()) {
+							$databaseLength = $fieldMapping['length'] ?? 255;
+							$cases = $enumTypeString::cases();
+							$maxLength = max(array_map(fn ($case): int => strlen($case->value), $cases) ?: [0]);
+							if ($maxLength > $databaseLength) {
+								$errors[] = RuleErrorBuilder::message(sprintf(
+									'Property %s::$%s length mismatch: maximum value length %s for enum %s exceeds database column length %s.',
+									$className,
+									$propertyName,
+									$maxLength,
+									$enumReflection->getDisplayName(),
+									$databaseLength,
+								))->identifier('doctrine.enumStringLength')->build();
+							}
 						}
 					}
 				}

--- a/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
+++ b/tests/Rules/Doctrine/ORM/EntityColumnRuleTest.php
@@ -445,6 +445,10 @@ class EntityColumnRuleTest extends RuleTestCase
 				'Property PHPStan\Rules\Doctrine\ORMAttributes\Foo::$type7 type mapping mismatch: backing type int of enum PHPStan\Rules\Doctrine\ORMAttributes\BazEnum does not match value type string of the database type array<string>.',
 				63,
 			],
+			[
+				'Property PHPStan\Rules\Doctrine\ORMAttributes\Foo::$type8 length mismatch: maximum value length 3 for enum PHPStan\Rules\Doctrine\ORMAttributes\FooEnum exceeds database column length 1.',
+				66,
+			]
 		]);
 	}
 

--- a/tests/Rules/Doctrine/ORM/data-attributes/enum-type.php
+++ b/tests/Rules/Doctrine/ORM/data-attributes/enum-type.php
@@ -61,4 +61,10 @@ class Foo
 	 */
 	#[ORM\Column(type: "simple_array", enumType: BazEnum::class)]
 	public array $type7;
+
+	#[ORM\Column(type: "string", length: 1, enumType: FooEnum::class)]
+	public FooEnum $type8;
+
+	#[ORM\Column(type: "string", length: 3, enumType: FooEnum::class)]
+	public FooEnum $type9;
 }


### PR DESCRIPTION
This adds a check for entity columns are mapped to a string-backed `enumType` to ensure that the maximum length of the enum values does not exceed the defined database column length.

(An additional future `enumType` check could be to ensure that integer-backed `enumType` columns with negative numbers are not mapped to an unsigned integer, but I will leave that for a different PR.)