### PR TITLE
perf: Check QueryBuilder method names before class hierarchies

### DIFF
--- a/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
@@ -88,10 +88,10 @@ class ReturnQueryBuilderExpressionTypeResolverExtension implements ExpressionTyp
 			if ($callerClassReflection->is(QueryBuilder::class)) {
 				return null; // covered by QueryBuilderMethodDynamicReturnTypeExtension
 			}
-			if ($callerClassReflection->is(EntityRepository::class) && $methodName === 'createQueryBuilder') {
+			if ($methodName === 'createQueryBuilder' && $callerClassReflection->is(EntityRepository::class)) {
 				return null; // covered by EntityRepositoryCreateQueryBuilderDynamicReturnTypeExtension
 			}
-			if ($callerClassReflection->is(EntityManagerInterface::class) && $methodName === 'createQueryBuilder') {
+			if ($methodName === 'createQueryBuilder' && $callerClassReflection->is(EntityManagerInterface::class)) {
 				return null; // no need to dive there
 			}
 		}


### PR DESCRIPTION
Reorder the `EntityRepository` and `EntityManager` `createQueryBuilder` guards so the cheap method-name comparison runs before `ClassReflection::is()`.

The resolver sees hundreds of thousands of calls, while these special cases apply only to `createQueryBuilder`. Avoiding hierarchy checks for every other method removes unnecessary reflection work without changing the accepted calls.

Benchmark: uncached Sylius analysis of 2,366 files with eight workers, five runs per variant. Median elapsed time fell from 28.91 s to 28.24 s (-2.3%) and aggregate user+sys CPU from 176.22 s to 173.44 s (-1.6%).

Benchmark run locally using PHPStan `2.2.x` and PHPStan-Doctrine `2.0.x` on MacOS with PHP 8.5.7