### PR TITLE
perf: Cache QueryBuilder class classification

### DIFF
--- a/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
@@ -25,6 +25,9 @@ class ReturnQueryBuilderExpressionTypeResolverExtension implements ExpressionTyp
 
 	private OtherMethodQueryBuilderParser $otherMethodQueryBuilderParser;
 
+	/** @var array<string, bool> */
+	private array $queryBuilderClasses = [];
+
 	public function __construct(
 		OtherMethodQueryBuilderParser $otherMethodQueryBuilderParser
 	)
@@ -85,7 +88,8 @@ class ReturnQueryBuilderExpressionTypeResolverExtension implements ExpressionTyp
 		$methodName = $call->name->name;
 
 		foreach ($callerType->getObjectClassReflections() as $callerClassReflection) {
-			if ($callerClassReflection->is(QueryBuilder::class)) {
+			$className = $callerClassReflection->getName();
+			if (($this->queryBuilderClasses[$className] ??= $callerClassReflection->is(QueryBuilder::class))) {
 				return null; // covered by QueryBuilderMethodDynamicReturnTypeExtension
 			}
 			if ($callerClassReflection->is(EntityRepository::class) && $methodName === 'createQueryBuilder') {


### PR DESCRIPTION
Cache whether each stable receiver class name is a `QueryBuilder` instead of repeating `ClassReflection::is()` for every call on that class.

Receiver classification is argument- and scope-independent, and the measured resolver performs more than 325,000 receiver reflection passes. Caching only this boolean avoids repeated hierarchy checks without caching scope-dependent method resolution.

This reduced median elapsed time from 28.45 s to 28.22 s (-0.8%) and aggregate user+sys CPU from 168.90 s to 167.37 s (-0.9%).

Benchmark run locally using PHPStan 2.2.x and PHPStan-Doctrine 2.0.x on MacOS with PHP 8.5.7