### PR TITLE
perf: Reuse the QueryBuilder ObjectType

### DIFF
--- a/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
@@ -25,11 +25,14 @@ class ReturnQueryBuilderExpressionTypeResolverExtension implements ExpressionTyp
 
 	private OtherMethodQueryBuilderParser $otherMethodQueryBuilderParser;
 
+	private ObjectType $queryBuilderObjectType;
+
 	public function __construct(
 		OtherMethodQueryBuilderParser $otherMethodQueryBuilderParser
 	)
 	{
 		$this->otherMethodQueryBuilderParser = $otherMethodQueryBuilderParser;
+		$this->queryBuilderObjectType = new ObjectType(QueryBuilder::class);
 	}
 
 	public function getType(Expr $expr, Scope $scope): ?Type
@@ -50,7 +53,7 @@ class ReturnQueryBuilderExpressionTypeResolverExtension implements ExpressionTyp
 
 		$returnType = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants())->getReturnType();
 
-		$returnsQueryBuilder = (new ObjectType(QueryBuilder::class))->isSuperTypeOf($returnType)->yes();
+		$returnsQueryBuilder = $this->queryBuilderObjectType->isSuperTypeOf($returnType)->yes();
 
 		if (!$returnsQueryBuilder) {
 			return null;

--- a/tests/Type/Doctrine/data/QueryResult/queryBuilderExpressionTypeResolver.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryBuilderExpressionTypeResolver.php
@@ -66,6 +66,11 @@ class QueryBuilderExpressionTypeResolverTest
 		$this->getQueryBuilder(...);
 	}
 
+	public function testNullableQueryBuilderIsNotInferred(EntityManagerInterface $em): void
+	{
+		assertType('Doctrine\\ORM\\QueryBuilder|null', $this->getNullableQueryBuilder($em));
+	}
+
 	private function adjustQueryBuilderToIndexByInt(QueryBuilder $qb): void
 	{
 		$qb->indexBy('m', 'm.intColumn');
@@ -94,6 +99,13 @@ class QueryBuilderExpressionTypeResolverTest
 	}
 
 	private static function getStaticQueryBuilder(EntityManagerInterface $em): QueryBuilder
+	{
+		return $em->createQueryBuilder()
+			->select('m')
+			->from(Many::class, 'm');
+	}
+
+	private function getNullableQueryBuilder(EntityManagerInterface $em): ?QueryBuilder
 	{
 		return $em->createQueryBuilder()
 			->select('m')


### PR DESCRIPTION
Create the `QueryBuilder` `ObjectType` once in the resolver constructor and reuse it for return-type compatibility checks.

The resolver is called more than 600,000 times in the measured workload. The `ObjectType` is immutable for this use, so allocating the same value for each method candidate only adds allocation and CPU overhead.

Benchmark: uncached Sylius analysis of 2,366 files with eight workers, five runs per variant. Median elapsed time fell from 28.91 s to 28.34 s (-2.0%) and aggregate user+sys CPU from 176.22 s to 169.68 s (-3.7%).

Benchmark run locally using PHPStan 2.2.x and PHPStan-Doctrine 2.0.x on MacOS with PHP 8.5.7