### PR TITLE
perf: Prefilter methods that cannot return QueryBuilder

### DIFF
--- a/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
+++ b/src/Type/Doctrine/QueryBuilder/ReturnQueryBuilderExpressionTypeResolverExtension.php
@@ -48,9 +48,22 @@ class ReturnQueryBuilderExpressionTypeResolverExtension implements ExpressionTyp
 			return null;
 		}
 
-		$returnType = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants())->getReturnType();
+		$queryBuilderType = new ObjectType(QueryBuilder::class);
+		$variants = $methodReflection->getVariants();
+		$canReturnQueryBuilder = false;
+		foreach ($variants as $variant) {
+			if (!$queryBuilderType->isSuperTypeOf($variant->getReturnType())->no()) {
+				$canReturnQueryBuilder = true;
+				break;
+			}
+		}
+		if (!$canReturnQueryBuilder) {
+			return null;
+		}
 
-		$returnsQueryBuilder = (new ObjectType(QueryBuilder::class))->isSuperTypeOf($returnType)->yes();
+		$returnType = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $variants)->getReturnType();
+
+		$returnsQueryBuilder = $queryBuilderType->isSuperTypeOf($returnType)->yes();
 
 		if (!$returnsQueryBuilder) {
 			return null;

--- a/tests/Type/Doctrine/data/QueryResult/queryBuilderExpressionTypeResolver.php
+++ b/tests/Type/Doctrine/data/QueryResult/queryBuilderExpressionTypeResolver.php
@@ -66,6 +66,11 @@ class QueryBuilderExpressionTypeResolverTest
 		$this->getQueryBuilder(...);
 	}
 
+	public function testNullableQueryBuilderIsNotInferred(EntityManagerInterface $em): void
+	{
+		assertType('Doctrine\\ORM\\QueryBuilder|null', $this->getNullableQueryBuilder($em));
+	}
+
 	private function adjustQueryBuilderToIndexByInt(QueryBuilder $qb): void
 	{
 		$qb->indexBy('m', 'm.intColumn');
@@ -94,6 +99,13 @@ class QueryBuilderExpressionTypeResolverTest
 	}
 
 	private static function getStaticQueryBuilder(EntityManagerInterface $em): QueryBuilder
+	{
+		return $em->createQueryBuilder()
+			->select('m')
+			->from(Many::class, 'm');
+	}
+
+	private function getNullableQueryBuilder(EntityManagerInterface $em): ?QueryBuilder
 	{
 		return $em->createQueryBuilder()
 			->select('m')


### PR DESCRIPTION
Inspect declared method variants before argument-dependent selection and return early only when every variant definitely cannot return `QueryBuilder`. Uncertain, generic, mixed, and compatible variants continue through the existing resolution path.

Most method candidates do not return `QueryBuilder`. This conservative filter avoids `ParametersAcceptorSelector` and downstream work for definite negatives while preserving fallback behavior whenever the declaration is not conclusive.

Benchmark: uncached Sylius analysis of 2,366 files with eight workers, five runs per variant. Median elapsed time fell from 28.91 s to 28.45 s (-1.6%) and aggregate user+sys CPU from 176.22 s to 170.75 s (-3.1%).

Benchmark run locally using PHPStan 2.2.x and PHPStan-Doctrine 2.0.x on MacOS with PHP 8.5.7