### PR TITLE
Fix the type of the connection received by the Connection::transactional() callback

### DIFF
--- a/stubs/DBAL/Connection.stub
+++ b/stubs/DBAL/Connection.stub
@@ -74,7 +74,7 @@ class Connection
 
     /**
      * @param-immediately-invoked-callable $func
-     * @param Closure(self): T $func
+     * @param Closure(static): T $func
      * @return T
      *
      * @template T

--- a/stubs/DBAL/Connection4.stub
+++ b/stubs/DBAL/Connection4.stub
@@ -78,7 +78,7 @@ class Connection
 
     /**
      * @param-immediately-invoked-callable $func
-     * @param Closure(self): T $func
+     * @param Closure(static): T $func
      * @return T
      *
      * @template T

--- a/tests/Type/Doctrine/DBAL/ConnectionTransactionalTest.php
+++ b/tests/Type/Doctrine/DBAL/ConnectionTransactionalTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Doctrine\DBAL;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class ConnectionTransactionalTest extends TypeInferenceTestCase
+{
+
+	/** @return iterable<mixed> */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/connection-transactional.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	/** @return string[] */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/pdo.neon'];
+	}
+
+}

--- a/tests/Type/Doctrine/DBAL/data/connection-transactional.php
+++ b/tests/Type/Doctrine/DBAL/data/connection-transactional.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ConnectionTransactional;
+
+use Doctrine\DBAL\Connection;
+use function PHPStan\Testing\assertType;
+
+class MyConnection extends Connection
+{
+
+}
+
+function (Connection $connection): void {
+	$result = $connection->transactional(function ($db) {
+		assertType('Doctrine\DBAL\Connection', $db);
+
+		return 1;
+	});
+	assertType('1', $result);
+};
+
+function (MyConnection $connection): void {
+	$result = $connection->transactional(function ($db) {
+		assertType('ConnectionTransactional\MyConnection', $db);
+
+		return 'foo';
+	});
+	assertType("'foo'", $result);
+
+	$connection->transactional(static function (MyConnection $db): void {
+	});
+};


### PR DESCRIPTION
Connection::transactional() calls the callback with $this, so the callback receives the actual connection instance: a closure typed with a subclass of Connection must be accepted when transactional() is called on that subclass.